### PR TITLE
fix(registry): materialize memories.jsonl on fresh install with zero records

### DIFF
--- a/docs/designs/memory-insight/registry-EARS.md
+++ b/docs/designs/memory-insight/registry-EARS.md
@@ -24,6 +24,7 @@
 - [ ] **MI-REG-012**: Migration shall be idempotent: re-running it shall not duplicate records if the registry already exists.
 - [ ] **MI-REG-013**: Legacy `memory.md` strength records whose text was already trimmed from the file (orphans) shall be skipped, and the migration shall report the skip count.
 - [ ] **MI-REG-014**: After a successful migration, the legacy `memory.md` shall be preserved on disk renamed to `memory.md.legacy` and shall no longer be loaded into agent context.
+- [ ] **MI-REG-019**: Migration shall materialize the `memories.jsonl` file even when zero records are migrated, so that an empty registry is represented by an empty (but present) JSONL file rather than an absent one.
 
 ## Backward Compatibility
 

--- a/skills/autolearn-reviewer/scripts/registry.py
+++ b/skills/autolearn-reviewer/scripts/registry.py
@@ -349,12 +349,17 @@ def migrate_from_legacy(persona_dir: Path) -> int:
             seen_ids.add(rec["id"])
             records.append(rec)
 
-    if records:
-        tmp = registry_path.with_suffix(registry_path.suffix + ".tmp")
-        with tmp.open("w", encoding="utf-8") as fh:
-            for r in records:
-                fh.write(json.dumps(r, ensure_ascii=False) + "\n")
-        os.replace(tmp, registry_path)
+    # @spec MI-REG-019: always materialize the registry file, even when zero
+    # records were migrated. Without this, a fresh install (or a persona whose
+    # legacy files contain only headers) leaves no memories.jsonl but still
+    # writes the .registry_migrated marker — so migrate_from_legacy short-
+    # circuits on every subsequent call and the file is never created. An empty
+    # JSONL file is the valid representation of an empty registry.
+    tmp = registry_path.with_suffix(registry_path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r, ensure_ascii=False) + "\n")
+    os.replace(tmp, registry_path)
 
     # @spec MI-REG-014: preserve legacy memory.md, stop loading it
     if memory_md.exists():

--- a/skills/autolearn-reviewer/scripts/test_registry.py
+++ b/skills/autolearn-reviewer/scripts/test_registry.py
@@ -124,3 +124,26 @@ def test_update_and_remove(tmp_path):
     assert reg.get(rec["id"])["tier"] == "hot"
     assert reg.remove(rec["id"]) is True
     assert reg.get(rec["id"]) is None
+
+
+def test_migration_with_zero_records_materializes_registry(tmp_path):
+    # Regression: a fresh install seeds memory.md / user-profile.md with headers
+    # only (no entries). Migration must still create an empty memories.jsonl so
+    # the installer's verification step passes and subsequent load() calls don't
+    # rely on lazy creation being re-triggered (the .registry_migrated marker
+    # would short-circuit migrate_from_legacy on every later call).
+    p = persona(tmp_path)
+    (p / "memory.md").write_text(
+        "# Autolearn Memory\n\n<!-- Managed by autolearn. -->\n\n",
+        encoding="utf-8",
+    )
+    (p / "user-profile.md").write_text(
+        "# User Profile\n\n<!-- Managed by autolearn. -->\n\n",
+        encoding="utf-8",
+    )
+
+    reg = R.MemoryRegistry(p)
+    records = reg.load()  # triggers migration
+    assert records == []
+    assert reg.path.exists()  # memories.jsonl materialized even though empty
+    assert reg.load() == []   # readable, still empty


### PR DESCRIPTION
## Problem

A fresh `./install.sh` run ended with a verification failure:

```
MISSING: ~/.autolearn/personas/default/memories.jsonl
Some files are missing — check the errors above.
```

## Root cause

The installer runs three commands in sequence:
1. `autolearn init` — seeds `memory.md` / `user-profile.md` with **headers only** (no entries)
2. `retention score` — triggers lazy registry migration via `MemoryRegistry.load()` → `migrate_from_legacy()`
3. `memory compose` — generates `memory.context.md`

In `migrate_from_legacy` (`registry.py`), the `memories.jsonl` write was gated behind `if records:`. On a fresh install the header-only legacy files yield **zero** entries, so:

- `records` is empty → the `if records:` block is skipped → **no `memories.jsonl` written**
- but the `.registry_migrated` marker **was** written (outside the guard), so every future `migrate_from_legacy` call short-circuits on the marker → the file is **never** created

The installer's verification step then fails on the missing file.

## Fix

Always materialize `memories.jsonl` during migration — an empty JSONL file is the valid representation of an empty registry.

| File | Change |
|------|--------|
| `registry.py` | Remove the `if records:` guard so the registry file is always written (atomically), even with zero records |
| `test_registry.py` | Add `test_migration_with_zero_records_materializes_registry` regression test reproducing the exact fresh-install scenario |
| `registry-EARS.md` | Add **MI-REG-019**: migration shall materialize the file even when zero records are migrated |

## Verification

- All 32 existing tests pass (`test_registry`, `test_retention`, `test_composer`, `test_shift`, `test_inspector_server`)
- New regression test would have failed before the fix (it asserts `reg.path.exists()` after a zero-record migration)
- End-to-end: simulated the exact installer flow (`init` → `retention score` → `memory compose`) in an isolated `AUTOLEARN_HOME` — `memories.jsonl` now exists (0 bytes) and verification passes
- Consumer audit (read-only subagent) confirmed all readers handle an empty file: `load()` returns `[]`, composer emits a header-only context, and sync push/pull treats files as opaque encrypted blobs (empty plaintext encrypts/decrypts fine)