### PR TITLE
fix(sync): make cross-machine sync work on large stores + headless hosts

### DIFF
--- a/skills/autolearn-reviewer/scripts/autolearn.py
+++ b/skills/autolearn-reviewer/scripts/autolearn.py
@@ -19,6 +19,7 @@ Commands:
 #     "python-slugify",
 #     "cryptography",
 #     "keyring",
+#     "keyrings.alt",  # PlaintextKeyring file backend for headless hosts w/o OS keychain
 #     "requests",
 # ]
 # ///

--- a/sync-server/src/server.ts
+++ b/sync-server/src/server.ts
@@ -14,6 +14,9 @@ export interface BuildServerOpts {
   db?: Db;
   /** Enable Fastify request logging. */
   logger?: boolean;
+  /** Max request body size in bytes (default 64 MiB). Needed because a large
+   *  memories.jsonl registry can exceed Fastify's ~1 MiB default. */
+  bodyLimit?: number;
 }
 
 export async function buildServer(
@@ -22,7 +25,12 @@ export async function buildServer(
   const openedHere = !opts.db;
   const db = opts.db ?? openDb(opts.dataDir ?? "./data");
 
-  const app = Fastify({ logger: opts.logger ?? false });
+  const envLimitMb = Number.parseInt(process.env.AUTOLEARN_SYNC_BODY_LIMIT_MB ?? "", 10);
+  const bodyLimit =
+    opts.bodyLimit ??
+    (Number.isFinite(envLimitMb) && envLimitMb > 0 ? envLimitMb * 1024 * 1024 : 64 * 1024 * 1024);
+
+  const app = Fastify({ logger: opts.logger ?? false, bodyLimit });
 
   app.addHook("onRequest", buildAuthHook(db));
 


### PR DESCRIPTION
Discovered while standing up Mac<->gb10 autolearn sync. Two independent blockers prevented sync from working in practice; both fixed here.

- `fix(sync-server): raise Fastify body limit for large memory stores` — `memories.jsonl` on a mature store is ~1.1 MB and exceeds Fastify's default ~1 MB body limit, so `sync push` failed with HTTP 413. Adds a configurable `bodyLimit` (default 64 MiB), overridable via `AUTOLEARN_SYNC_BODY_LIMIT_MB`.
- `fix(autolearn): add keyrings.alt for headless Linux keychain fallback` — on a headless host (no GUI/D-Bus session) `gnome-keyring` is unusable, and the documented keychain fallback is a password prompt that hangs the plugin's detached background sync. `keyrings.alt.file.PlaintextKeyring` provides a file backend that works non-interactively; declares the dependency so `uv run` can import it when a host opts in via `keyringrc.cfg`.

Verified end-to-end: Mac pushed 6 files, gb10 pulled and decrypted (0 tampered), bidirectional push confirmed.