### PR TITLE
feat(reviewer): capture conditionalized failure diagnoses (dead-end paths)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Self-improvement engine for [OpenCode](https://opencode.ai). Learns from your conversations, captures corrections and preferences, and escalates behavioral rules so your coding agent improves over time.
 
+<p align="center">
+  <a href="https://www.linkedin.com/feed/update/urn:li:activity:7481434645415477248/">
+    <img src="assets/junpeng-lao-quote.svg" alt="Junpeng Lao: Really like opencode-autolearn, it's the worklog/self-improvement loop done properly." width="720">
+  </a>
+</p>
+
 ## How it works
 
 1. **Conversation monitoring** — A plugin hooks into OpenCode events, counting turns and buffering messages (with secret redaction).

--- a/assets/junpeng-lao-quote.svg
+++ b/assets/junpeng-lao-quote.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 300" role="img" aria-label="Endorsement from Junpeng Lao: Really like opencode-autolearn, it's the worklog/self-improvement loop done properly.">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4f46e5"/>
+      <stop offset="55%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#9333ea"/>
+    </linearGradient>
+    <linearGradient id="sheen" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.14"/>
+      <stop offset="55%" stop-color="#ffffff" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#c4b5fd"/>
+      <stop offset="100%" stop-color="#f0abfc"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Card -->
+  <rect x="2" y="2" width="916" height="296" rx="20" fill="url(#bg)"/>
+  <rect x="2" y="2" width="916" height="296" rx="20" fill="url(#sheen)"/>
+  <rect x="2.75" y="2.75" width="914.5" height="294.5" rx="19.25" fill="none" stroke="#ffffff" stroke-opacity="0.18" stroke-width="1.5"/>
+
+  <!-- Decorative quote-mark watermark -->
+  <text x="34" y="132" font-family="Georgia, 'Times New Roman', serif" font-size="170" fill="#ffffff" fill-opacity="0.12" font-weight="700">&#8220;</text>
+
+  <!-- Quote -->
+  <text font-family="system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="29" font-weight="600" fill="#ffffff">
+    <tspan x="92" y="104">Really like opencode-autolearn, it&#8217;s the</tspan>
+    <tspan x="92" y="144">worklog/self-improvement loop done properly.</tspan>
+  </text>
+
+  <!-- Divider -->
+  <rect x="92" y="174" width="52" height="3.5" rx="1.75" fill="url(#accent)"/>
+
+  <!-- Attribution -->
+  <text x="92" y="208" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="21" font-weight="700" fill="#ffffff">Junpeng Lao</text>
+  <text font-family="system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif" font-size="15" fill="#e9d5ff">
+    <tspan x="92" y="234">PyMC &amp; BlackJAX core dev &#183; Co-author,</tspan>
+    <tspan x="92" y="256">Bayesian Modeling and Computation in Python</tspan>
+  </text>
+</svg>

--- a/docs/designs/review-agent/LLD.md
+++ b/docs/designs/review-agent/LLD.md
@@ -99,6 +99,10 @@ The reviewer classifies conversation signals into three tiers:
 4. Frustration about repetition: "again?", "I keep telling you"
 5. Explicit instruction to remember: "remember this", "write that down"
 6. Workarounds that worked: non-obvious techniques that resolved an issue
+6a. Failure diagnoses with root cause: dead-end paths stated with all three
+    of trigger condition + root cause + fix/workaround. The inverse of #6 —
+    captures WHY something didn't work. A bare "X is broken" stays excluded
+    (no condition/cause/fix → hardens into a refusal).
 
 ### Moderate Signals (act if seen more than once)
 
@@ -118,7 +122,9 @@ The reviewer classifies conversation signals into three tiers:
 - Clarification questions
 - Normal conversational flow
 - Environment-dependent failures
-- Negative claims about tools that could harden into refusals
+- **Bare** negative claims about tools that could harden into refusals (e.g., "X is broken").
+  **Conditionalized failure diagnoses** (condition + root cause + workaround) are NOT excluded --
+  they are captured as strong signal #6a (RA-CE-010a). (Refined 2026-07-11)
 
 ## Action Protocol
 

--- a/docs/designs/review-agent/LLD.md
+++ b/docs/designs/review-agent/LLD.md
@@ -193,8 +193,10 @@ This creates an audit trail in observations.jsonl for detecting systematic captu
 - Never modify project source code (only write to `~/.autolearn/`)
 - Never write secrets, API keys, or credentials
 - Max 2 new skills per review
-- Keep memory.md under 3000 characters
-- Keep user-profile.md under 2000 characters
+- The memory + user registries are unbounded — entries leave only via
+  Ebbinghaus decay (cold past `eviction_grace_days`, default 90), not a
+  character cap. Prefer `memory strengthen` over `memory add` for semantic
+  duplicates to keep the registry clean and the reinforcement signal accurate.
 - If unsure about signal strength, lean toward not recording
 
 ## Review Output
@@ -218,7 +220,9 @@ Autolearn review complete: nothing to record.
 
 1. **Review of a review**: Buffer depth guard in plugin prevents this; reviewer never sees review content.
 2. **Conversation with no learning signals**: Valid outcome — output "nothing to record."
-3. **Memory full**: CLI trims oldest entries automatically.
+3. **Registry at scale**: the memory + user registries are unbounded; entries
+   leave only via Ebbinghaus decay (cold past `eviction_grace_days`), so there
+   is no "full" state. Run `retention score` periodically to refresh tiers.
 4. **Skill creation failure (duplicate)**: CLI exits with error; reviewer should handle gracefully.
 5. **Empty conversation**: Plugin won't spawn review if buffer is empty.
 

--- a/docs/designs/review-agent/conversation-evaluation-EARS.md
+++ b/docs/designs/review-agent/conversation-evaluation-EARS.md
@@ -9,10 +9,11 @@
 - [x] **RA-CE-002a**: The reviewer shall evaluate each user message for declarative workflow specification signals — statements where the user describes how they want a recurring task or workflow to work, even when no mistake was made (e.g., "they should be one post one week", "we don't use global pip anywhere here", "LinkedIn should follow Bluesky schedule").
 - [x] **RA-CE-003**: The reviewer shall evaluate each user message for frustration-about-repetition signals (e.g., "again?", "I keep telling you").
 - [x] **RA-CE-004**: The reviewer shall evaluate the conversation for workarounds that resolved an issue (non-obvious techniques, debugging paths).
+- [x] **RA-CE-004a**: The reviewer shall evaluate the conversation for conditionalized failure diagnoses — dead-end paths where the agent or user determined WHY something failed, stated with all three of (a) trigger condition, (b) root-cause reason, (c) fix or workaround — even when the path did not produce a success. The reason something didn't work is denser than the reason something did.
 
 ## Signal Classification
 
-- [x] **RA-CE-005**: The reviewer shall classify strong signals (corrections, explicit preferences, declarative workflow specs, frustration, explicit remember instructions, successful workarounds) as always requiring action.
+- [x] **RA-CE-005**: The reviewer shall classify strong signals (corrections, explicit preferences, declarative workflow specs, frustration, explicit remember instructions, successful workarounds, **conditionalized failure diagnoses**) as always requiring action.
 - [x] **RA-CE-006**: The reviewer shall classify moderate signals (tool choice patterns, code style, workflow patterns, skill gaps) as requiring action only when observed more than once.
 - [x] **RA-CE-007**: The reviewer shall classify weak signals (contextual facts, environment details) as recordable but not worthy of skill creation.
 
@@ -28,7 +29,8 @@
 
 - [x] **RA-CE-008**: The reviewer shall not capture one-time task instructions (e.g., "add a button", "rename this variable").
 - [x] **RA-CE-009**: The reviewer shall not capture clarification questions.
-- [x] **RA-CE-010**: The reviewer shall not capture negative claims about tools that could harden into agent refusals (e.g., "X is broken").
+- [x] **RA-CE-010**: The reviewer shall not capture BARE negative claims about tools that could harden into over-generalized agent refusals (e.g., "X is broken", "don't use X" stated without a condition, a root cause, or a workaround).
+- [x] **RA-CE-010a**: The reviewer SHALL capture conditionalized failure diagnoses — "X fails WHEN `<condition>` BECAUSE `<root cause>`; workaround is `<Y>`" — as strong signals (per RA-CE-004a/RA-CE-005). A conditionalized negative is a guardrail with an escape hatch, not a refusal. The test: if the trigger condition AND the workaround can both be stated, capture it; otherwise skip it. (Refined 2026-07-11 after Junpeng Lao flagged that autolearn was skipping all failure paths; see https://junpenglao.xyz/writing/at-the-edge-of-what-you-know/)
 
 ## Meta-Pattern Detection
 

--- a/skills/autolearn-reviewer/SKILL.md
+++ b/skills/autolearn-reviewer/SKILL.md
@@ -42,6 +42,18 @@ action by writing to files.
    "note this for next time"
 6. **Workarounds that worked**: non-obvious techniques, debugging paths,
    fixes that resolved an issue
+6a. **Failure diagnoses with root cause (conditionalized negatives)**:
+   the dead-end paths that are *denser than the reason something worked*.
+   Capture a failure ONLY when you can state all three: (a) the TRIGGER
+   CONDITION under which it fails, (b) the ROOT-CAUSE reason, and (c) the
+   FIX or WORKAROUND. With all three it is a GUARDRAIL with an escape
+   hatch, not a blind refusal — record it (skill if repeatable, memory
+   if one-off). Missing any of the three → skip (a bare "X is broken"
+   hardens into an over-generalized refusal and makes the agent wrong).
+   This is the inverse of #6: #6 captures what worked, this captures WHY
+   something didn't and the path around it. (Added 07-11 after Junpeng
+   Lao flagged the gap: the reviewer was skipping ALL failure paths,
+   losing the densest knowledge in the conversation.)
 7. **Token-efficiency mandate (proactive, always act)**: the PURPOSE of
    recording memories, updating the user profile, and creating/patching skills
    is to make FUTURE interactions LESS token-heavy by shortcutting repetitive
@@ -80,7 +92,14 @@ action by writing to files.
 - Clarification questions
 - Normal conversational flow
 - Environment-dependent failures (missing binaries, network issues)
-- Negative claims about tools ("X is broken") that could harden into refusals
+- **Bare** negative claims about tools ("X is broken", "don't use X") that
+  could harden into blanket refusals. A **conditionalized failure diagnosis**
+  — trigger condition + root cause + fix/workaround — is NOT a bare negative;
+  capture it under strong signal **#6a**. The test: can you state the condition
+  under which it fails AND the workaround? If yes, record it; if no, skip it.
+  (Refined 2026-07-11 after Junpeng Lao flagged that autolearn was skipping all
+  failure paths; his tuningfork project captures dead ends on purpose — see
+  https://junpenglao.xyz/writing/at-the-edge-of-what-you-know/)
 - Session-specific transient errors
 
 ## Generalization Rule


### PR DESCRIPTION
## Why

Junpeng Lao ([@junpenglao](https://github.com/junpenglao)) flagged a design gap in his comment on the opencode-autolearn announcement: the reviewer learned only from what *worked* and skipped all failure paths ("no negatives that harden into refusals"). His [tuningfork](https://github.com/blackjax-devs/tuningfork) project does the opposite — captures dead ends on purpose — because *"the reason something didn't work is denser than the reason something did"* ([essay](https://junpenglao.xyz/writing/at-the-edge-of-what-you-know/)).

These two positions aren't actually in conflict:
- **Bare negatives** ("X is broken") → correctly skipped; they over-generalize into blind refusals.
- **Conditionalized failure diagnoses** ("X fails WHEN *condition* BECAUSE *root cause*; workaround is *Y*") → dense, valuable, and a *guardrail with an escape hatch*, not a refusal.

The old rule lumped both together. This PR splits them.

## What changed

New strong signal **6a**: capture a failure diagnosis **only** when all three components are present — (a) trigger condition, (b) root-cause reason, (c) fix/workaround. Missing any → still skip (bare negative). With all three → record as a skill (if repeatable) or memory.

Traceable across all three layers:
| Layer | Change |
|---|---|
| `skills/autolearn-reviewer/SKILL.md` | Signal **6a** + refined "What NOT to Capture" (bare-only test) |
| `conversation-evaluation-EARS.md` | **RA-CE-004a** (detect), **RA-CE-005** (classify as strong), **RA-CE-010** refined + **RA-CE-010a** (capture) |
| `LLD.md` | Signal **6a** in Strong Signals + Excluded cross-ref |

## Commits

1. `feat(reviewer): capture conditionalized failure diagnoses as strong signals` — the core feature (SKILL + EARS + LLD signal classification)
2. `docs(review-agent): remove stale bounded-model char caps from LLD` — fixes LLD prose left over from the unbounded-registry migration ("Keep memory.md under 3000 characters" etc.), so a reader doesn't enforce caps that no longer exist