### PR TITLE
fix: restore reviewer escalation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Autolearn ships **two** Python CLIs that work together. The README sections abov
 | `autolearn.py` | `~/.agents/skills/autolearn-reviewer/scripts/autolearn.py` | `~/.autolearn/` | Memory, skills, curator, search |
 | `improve.py` | `~/.agents/skills/self-improving-agent/scripts/improve.py` | `~/.agent-improvement/rules.yaml` | Behavioral rule tracking and AGENTS.md escalation |
 
-The reviewer records corrections via `improve.py observe ...` (Step 3 of the reviewer skill), then `improve.py escalate --apply` promotes repeated rules into the appropriate `AGENTS.md` file. Common commands:
+The reviewer records corrections via `improve.py observe ...` (Step 4 of the reviewer skill), then `improve.py escalate --apply` promotes repeated rules into the appropriate `AGENTS.md` file. Common commands:
 
 ```bash
 uv run ~/.agents/skills/self-improving-agent/scripts/improve.py status          # show all rules + counts

--- a/docs/designs/review-agent/LLD.md
+++ b/docs/designs/review-agent/LLD.md
@@ -140,9 +140,10 @@ uv run $HOME/.agents/skills/autolearn-reviewer/scripts/autolearn.py search query
 
 ### Step 3: Record Observations
 
-The old `improve.py observe` / `~/.agent-improvement/` store was removed on 2026-06-16.
-Capture all corrections and preferences directly through the durable mechanisms below
-(Steps 4–6). Rules phrased as imperatives.
+Record corrections and recurring preferences in the behavioral-rule store with
+`improve.py observe`, then capture the corresponding durable memory, user-profile, or
+skill update in Steps 4–6. The `self-improving-agent` skill owns cross-project rule
+tracking and escalation to `AGENTS.md`; rules should be phrased as imperatives.
 
 ### Step 4: Update Memory
 

--- a/docs/designs/review-agent/action-execution-EARS.md
+++ b/docs/designs/review-agent/action-execution-EARS.md
@@ -4,7 +4,7 @@
 
 ## Observation Recording
 
-- [x] **RA-AE-001**: When the reviewer identifies a strong signal, the reviewer shall record it via the durable mechanisms (`autolearn.py memory add`, `user add`, or `skill create/patch`) with the rule phrased as an imperative. (The old `improve.py observe` store was removed 2026-06-16.)
+- [x] **RA-AE-001**: When the reviewer identifies a strong signal, the reviewer shall record it in the behavioral-rule store via `improve.py observe` and via the durable mechanisms (`autolearn.py memory add`, `user add`, or `skill create/patch`) with the rule phrased as an imperative.
 - [x] **RA-AE-002**: The reviewer shall assign a domain to each observation (e.g., python-tooling, git-practices, code-style) when identifiable.
 
 ## Memory Updates

--- a/skills/autolearn-reviewer/SKILL.md
+++ b/skills/autolearn-reviewer/SKILL.md
@@ -153,12 +153,20 @@ uv run $HOME/.agents/skills/autolearn-reviewer/scripts/autolearn.py search query
 **First-time setup:** If the search returns an error about the index not existing,
 run `autolearn.py search init` first, then retry the query.
 
-### Step 4: Record observations (via memory + user profile + skills)
+### Step 4: Record observations (behavioral rules, memory, user profile, and skills)
 
-The old `improve.py observe` / `~/.agent-improvement/rules.yaml` observation store
-was removed on 2026-06-16 (along with the self-improving-agent skill, which shipped
-`improve.py`). There is no separate observation store anymore. Capture all corrections
-and preferences directly through the durable mechanisms below:
+Capture each correction or recurring preference in the behavioral-rule store as well
+as in the durable mechanisms below. The `self-improving-agent` skill ships
+`improve.py` and tracks repeated rules across projects:
+
+```bash
+uv run $HOME/.agents/skills/self-improving-agent/scripts/improve.py observe "<rule>" \
+  --project "<project>" --domain "<domain>" --context "<what happened>"
+```
+
+At the end of a review, run `improve.py due`. For rules that are due, follow the
+`self-improving-agent` skill's escalation protocol; `improve.py escalate --apply`
+updates the appropriate `AGENTS.md` and records the rule as written.
 
 - **Step 5** (memory registry): durable cross-session lessons
 - **Step 6** (user registry, `type="user"`): communication/workflow preferences


### PR DESCRIPTION
Fix stale reviewer and design documentation that incorrectly said the installed `self-improving-agent` workflow had been removed.

The reviewer now records behavioral rules with `improve.py` and follows the documented escalation flow.