### PR TITLE
feat(certified-procedures): falsify skills + golden-path shortcuts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,15 @@ Start with the [High-Level Design](./high-level-design.md) — it has a status c
 - `sync push` all-personas iteration (SYNC-PER-012/013) — currently pushes active persona only
 - Project-level `.autolearn-persona` file (SYNC-PER-014) — project-specific persona mapping
 - Salt auto-bootstrap — Phase 1 requires manual `scp ~/.autolearn/.encryption_salt` to new machines
+- Certified Procedures correlation-falsification (CP-FAL-005) — probabilistic, suggestion-only, deferred behind the deterministic path
+
+### In flight
+
+- [Certified Procedures LLD](./designs/certified-procedures/LLD.md) (+ [EARS](./designs/certified-procedures/certified-procedures-EARS.md)) — falsify skills against ground-truth tool outcomes (Loop 1) + golden-path shortcut extraction (Loop 2), on a shared `outcomes.py` spine. See HLD Decisions 10–12.
+
+> Note: Memory Insight (`docs/designs/memory-insight/`) is **shipped** (registry,
+> retention, composer, shift detector, inspector UI all live) — the HLD status
+> rows reflect this.
 
 ## Conventions
 

--- a/docs/designs/certified-procedures/LLD.md
+++ b/docs/designs/certified-procedures/LLD.md
@@ -1,0 +1,375 @@
+# Certified Procedures - Low-Level Design
+
+**Created**: 2026-07-16
+**HLD Link**: ../../high-level-design.md
+
+## Overview
+
+Certified Procedures gives autolearn the ability to **falsify its own
+procedures** (skills) and to **shortcut roundabout workflows to a golden
+path**. It imports the discipline of the Schema ARC-AGI-3 harness — maintain a
+backtested, executable model of the world and let reality falsify it — adapted
+to the non-deterministic, open world of a software repository.
+
+The earlier "Certified Memory" concept (backtesting prose *memories* against
+prose conversation snippets) was rejected after review: prose-vs-prose retains
+none of Schema's verifiability, the FTS5 search index deliberately excludes
+tool-call/outcome data (session-search DD4), and lexical contradiction is
+polarity-blind and drift-confounding. The sound target is **skills**
+(autolearn's program-analog), falsified against **ground-truth-bearing tool
+outcomes** drawn from `opencode.db`.
+
+Two co-equal loops share one data spine:
+
+- **Loop 1 — Falsify (correctness).** Verify a skill's procedure still produces
+  its claimed outcome; demote and flag skills that fail. Deterministic first.
+- **Loop 2 — Efficiency (golden path).** Detect expensive roundabout tool-call
+  sequences in past sessions, extract the direct ("golden") invocation, and
+  promote it to a skill/memory — gated by Loop 1 verification before promotion.
+
+```
+opencode.db.part  ── tool parts · step-finish parts · skill-load parts
+        │
+        ▼
+outcomes.py  ── SHARED SPINE (index all three; incremental; ground-truth-weighted)
+        │              side effect: derives per-skill use_count → repairs .usage.json
+        ├─────────────────────────┐
+        ▼                         ▼
+falsify.py (Loop 1)          shortcuts.py (Loop 2)
+ run test_*.py / verify:       detect roundabout sequences (cost = Σ step tokens)
+ declared → deterministic      extract golden path → skill/memory,
+ verdict {pass|fail|inconclusive}   PROMOTION GATED by falsify before auto-promote
+        │
+        ▼
+consequence layer (curator + improve.py retire-the-loser;
+ deterministic fail → auto-demote + flag)
+        │
+        ▼
+inspector UI  ── per-skill verdict · reuse count · est. tokens-saved
+```
+
+## Context — why skills + outcomes, not memories + text
+
+Schema's `world_model.py` is executable code whose predictions are checked
+against ground truth ("393/393 exact replay"). A repo is not a closed
+deterministic system, so exact replay is impossible. But
+`opencode.db` *does* carry structured, ground-truth-bearing evidence that the
+existing FTS5 index throws away:
+
+- **106k+ tool parts** with `{tool, state.status, state.input, state.output}` —
+  including **2,485 with `state.status = "error"`** (a ground-truth failure bit).
+- **~98k `step-finish` parts** carrying `tokens {input, output, reasoning,
+  cache.read, cache.write}` + `cost` — a real per-step token ledger.
+- **1,394 `tool = "skill"` parts** carrying `state.input.name` (the skill slug)
+  — direct skill→session linkage, and the basis for the reuse ledger.
+
+The critical epistemic rule: **"replay against recorded history" only
+falsifies where the outcome carries a ground-truth bit** — a test pass/fail, a
+non-zero exit, or a user correction immediately after. A raw `output` (grep
+results, a file dump) is data, not a verdict. The falsifier therefore weights
+outcomes by ground-truth strength: **test result > exit code > user correction
+> raw output (ignored)**.
+
+## Data Models
+
+### `outcomes.db` (new; persona-local, NOT synced)
+
+Same pattern as `search.db` (session-search DD1): a separate SQLite DB under
+autolearn's control, read from `opencode.db`, never written to it. Rebuilt from
+scratch at any time. Persona-local because `opencode.db` is machine-local by
+nature; verdict provenance is therefore machine-local, not canonical.
+
+```sql
+-- High-water mark (mirrors search.db index_state)
+CREATE TABLE IF NOT EXISTS index_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+-- Indexed tool-call outcomes
+CREATE TABLE IF NOT EXISTS tool_outcome (
+    part_id     TEXT PRIMARY KEY,
+    session_id  TEXT NOT NULL,
+    message_id  TEXT NOT NULL,
+    seq         INTEGER NOT NULL,          -- ordering within a session (time_created, id)
+    time_created INTEGER NOT NULL,
+    tool        TEXT NOT NULL,             -- "bash", "grep", "skill", ...
+    status      TEXT NOT NULL,             -- "completed" | "error" | "pending" | "running"
+    skill_name  TEXT,                      -- populated when tool == "skill" (state.input.name)
+    input_json  TEXT,                      -- raw state.input (for roundabout-detection heuristics)
+    output_peek TEXT,                      -- first N chars of state.output (evidence display only)
+    gt_strength INTEGER NOT NULL DEFAULT 0 -- 0 none | 1 raw | 3 exit-code | 4 test
+                                              -- (2 correction RESERVED for the deferred
+                                              --  probabilistic layer; not assigned today)
+);
+CREATE INDEX IF NOT EXISTS to_session_seq ON tool_outcome (session_id, seq);
+CREATE INDEX IF NOT EXISTS to_skill ON tool_outcome (skill_name);
+CREATE INDEX IF NOT EXISTS to_tool_status ON tool_outcome (tool, status);
+
+-- Per-step token ledger (from step-finish parts)
+CREATE TABLE IF NOT EXISTS step_cost (
+    part_id     TEXT PRIMARY KEY,
+    session_id  TEXT NOT NULL,
+    seq         INTEGER NOT NULL,
+    time_created INTEGER NOT NULL,
+    reason      TEXT,                      -- "tool-calls", "stop", ...
+    tokens_in   INTEGER NOT NULL DEFAULT 0,
+    tokens_out  INTEGER NOT NULL DEFAULT 0,
+    tokens_reasoning INTEGER NOT NULL DEFAULT 0,
+    cache_read  INTEGER NOT NULL DEFAULT 0,
+    cache_write INTEGER NOT NULL DEFAULT 0,
+    cost        REAL NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS sc_session_seq ON step_cost (session_id, seq);
+```
+
+#### Ground-truth strength classification (`gt_strength`)
+
+| Value | Meaning | Source |
+|------:|---------|--------|
+| 4 | test result | `tool="bash"` (or `task`/run) whose `input`/`output` indicates a test runner (`pytest`, `vitest`, `npm test`, `go test`, …) and whose output contains a pass/fail summary |
+| 3 | exit code | `tool="bash"` with a non-zero exit / explicit failure marker in `output`, or `status="error"` |
+| 2 | correction | a user `text` part within a small window *after* the tool call that matches a correction cue (reuses the reviewer's signal taxonomy) |
+| 1 | raw output | structured output exists but carries no ground-truth bit (grep/read/edit output) |
+| 0 | none | no usable outcome |
+
+The falsifier and the roundabout detector only act on `gt_strength >= 2`.
+
+### Skill verdict (`verdicts.json`) — persona-local
+
+A single JSON object under the persona dir, keyed by skill id (latest record
+per skill; atomic tmp+rename write). The pairing-ledger analog.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| skill | string | Skill slug (matches `.usage.json` key). |
+| verdict | `"pass"` \| `"fail"` \| `"inconclusive"` | Result of the strongest available check. |
+| method | `"test-suite"` \| `"declared"` \| `"none"` | How it was checked. |
+| evidence | string | Short human-readable pointer (failing test name, error tail, command). |
+| checked_at | string | ISO datetime. |
+| fail_count | int | Consecutive failures (resets on pass). |
+
+### Config additions (`config.yaml`)
+
+```yaml
+# Certified Procedures
+outcomes_index_batch: 5000          # parts per indexing pass
+roundabout_help_depth: 2            # >= N help/--help probes in a row = roundabout
+roundabout_error_run: 3             # >= N consecutive errors before a success = roundabout
+roundabout_recent_sessions: 50      # how many recent sessions to scan
+shortcut_promote_min_tokens: 2000   # only promote shortcuts saving >= this many tokens
+falsify_fail_demote_after: 1        # consecutive fails before auto-demote
+```
+
+## Component APIs
+
+All modules import nothing from `autolearn.py`; `autolearn.py` imports them and
+wires subparsers. Each ships a sibling `test_<module>.py` (pytest, `uv run
+pytest`). `@spec CP-*` tags map back to the EARS files.
+
+### outcomes.py — the shared spine
+
+```python
+OUTCOMES_DB_NAME = "outcomes.db"
+
+class OutcomeIndex:
+    def __init__(self, outcomes_db: Path, opencode_db: Path): ...
+    def init_schema(self) -> None
+    def index(self, *, full: bool = False) -> dict     # incremental high-water mark
+                                                         # returns {tool_parts, step_parts,
+                                                         #          skill_loads, gt>=2, errors}
+    def close(self) -> None
+
+# Data-returning query API (the gap the critique found in search.py):
+def list_tool_outcomes(index, *, session_id=None, tool=None, skill=None,
+                       min_gt=0, limit=None) -> list[dict]
+def session_sequences(index, session_id) -> list[dict]  # ordered tool+step rows for a session
+def skill_use_counts(index) -> dict[str, int]            # skill_name -> load count (repairs .usage.json)
+def status(index) -> dict
+
+def classify_gt(part_data: dict) -> int                  # 0..4 (see table)
+def is_test_command(tool: str, input_json: dict, output_peek: str) -> bool
+def exit_code_of(tool: str, status: str, input_json: dict, output_peek: str) -> int | None
+def cmd_outcomes_init(args)
+def cmd_outcomes_status(args)
+```
+
+**Incremental indexing** mirrors `search.db` DD2: track the last indexed
+`time_created` in `index_state`; on each `index`, scan `part` rows newer than
+the mark, dispatch on `json_extract(data,'$.type')` to `tool` / `step-finish`
+(and ignore the rest), classify ground-truth, insert. `--full` truncates first.
+
+**`.usage.json` reuse-ledger repair:** `skill_use_counts()` derives each
+skill's `use_count` from `tool='skill'` part counts. The curator / a dedicated
+`outcomes sync-usage` step writes these back into `.usage.json` (the field
+exists but is never incremented today — skill-management LLD:91).
+
+### falsify.py — Loop 1 (deterministic first)
+
+```python
+DEFAULT_CONFIG = {...}  # falsify_fail_demote_after, etc.
+
+def claims_of(skill_dir: Path) -> list[dict]
+    # Discover a skill's falsifiable claims, strongest first:
+    #  1. test-suite: scripts/test_*.py exists  -> {"method":"test-suite", "path":...}
+    #  2. declared:   SKILL.md frontmatter "verify:" block
+    #                 {commands:[...], expect_exit:0, expect_output:"..."} -> {"method":"declared",...}
+    #  3. none        -> []
+
+def run_claim(claim: dict, *, cwd: Path, timeout: int) -> dict
+    # {"verdict":"pass"|"fail"|"inconclusive", "evidence":..., "method":...}
+    # Executes the claim in the skill dir; inconclusive on timeout/missing-deps.
+
+def verify_skill(skill_dir: Path, *, usage: dict, config: dict) -> dict
+    # Picks the strongest claim; returns a verdict record (see verdicts.json).
+
+def verify_all(skills_dir: Path, verdicts_path: Path, *, config: dict,
+               dry_run: bool = False) -> dict
+    # Verify every active skill; write verdicts.json; return {pass, fail, inconclusive, none}.
+
+def apply_consequences(usage: dict, verdicts: list[dict], *, config: dict,
+                       dry_run: bool = False) -> dict
+    # fail_count >= falsify_fail_demote_after -> set state "stale", flag for patch.
+    # (Deterministic fails are safe to act on — per user decision.)
+
+def cmd_falsify_run(args)        # --id NAME | --all | --dry-run
+def cmd_falsify_verdicts(args)   # print the ledger
+```
+
+**Deterministic-first scope:** only `test-suite` and `declared` claims are
+evaluated (the user's chosen first path). Skills with no claim get
+`verdict: inconclusive, method: none` and are left untouched. Correlation-based
+falsification (skill-load → subsequent ground-truth outcomes) is **deferred** —
+it is suggestion-only and must never auto-demote.
+
+**Batch scope:** `verify_all` scans the persona's `skills/` dir
+(autolearn-created skills — matching the curator's lifecycle scope). Verifying
+*all* discoverable skills under `~/.agents/skills/` (where most scripted,
+falsifiable skills live) is a follow-up gated behind an allowlist, since batch
+re-execution of every installed skill's tests is expensive and noisy. The
+outcome index, reuse-ledger derivation, and roundabout detection already cover
+all data regardless of where a skill lives.
+
+**Safety:** `run_claim` runs the claim with the skill dir as `cwd`, a timeout,
+and **no network**. Declared commands are restricted to a safe subset
+(read-only commands, test runners); anything else returns `inconclusive` rather
+than executing. Live re-execution sandboxing is explicitly limited here to keep
+side effects bounded.
+
+### shortcuts.py — Loop 2 (efficiency)
+
+```python
+DEFAULT_CONFIG = {...}  # roundabout_help_depth, roundabout_error_run, etc.
+
+def detect_roundabouts(index, *, recent_sessions: int, config: dict) -> list[dict]
+    # Scan recent sessions' ordered tool_outcome rows for expensive-discovery
+    # patterns:
+    #   (a) help-chain: >= roundabout_help_depth consecutive --help/-h probes
+    #       before the working command.
+    #   (b) error-run:  >= roundabout_error_run consecutive error-status tool
+    #       calls immediately before a completed one with the same tool.
+    # Returns [{session_id, kind, start_seq, end_seq, tool, cost_tokens,
+    #           golden_command}] where cost_tokens = Σ step_cost between the
+    #           markers, and golden_command is the input of the successful
+    #           terminal call.
+
+def session_token_cost(index, session_id, start_seq, end_seq) -> int
+def cmd_shortcuts_detect(args)   # --recent N | --dry-run
+def cmd_shortcuts_list(args)     # list detected candidates awaiting promotion
+```
+
+**Promotion is gated by Loop 1.** A detected golden command is *not* auto-added
+as a skill. It is staged as a candidate; `falsify.verify_skill` must confirm
+the direct command still works (deterministic check) before the candidate is
+handed to the existing reviewer capture path (`skill create/patch` or
+`memory add` — signal #7). This reuses Loop 1 as Loop 2's safety layer and
+stops lucky one-off commands from hardening into bad shortcuts.
+
+### inspector UI + composer integration
+
+- `inspector_server.py` gains `/api/procedures` (per-skill verdict + reuse
+  count + method) and `/api/shortcuts` (detected candidates with est.
+  tokens-saved). The overview gains a "failing procedures" count.
+- The memory **composer** is unaffected (skills are loaded on demand, not
+  injected wholesale like memory); the `verdicts.json` is read by the curator
+  and the inspector only.
+
+## CLI Commands (added to `autolearn.py`)
+
+Three top-level nouns, parallel to `retention` / `topics`:
+
+| Command | Description |
+|---------|-------------|
+| `outcomes init [--full]` | Build/update the outcome index from opencode.db |
+| `outcomes status` | Index size, coverage, gt-strength histogram |
+| `falsify run [--id NAME \| --all] [--dry-run]` | Verify skills; write verdicts; auto-demote fails |
+| `falsify verdicts` | Print the per-skill verdict ledger |
+| `shortcuts detect [--recent N] [--dry-run]` | Detect roundabout paths; stage golden-path candidates |
+| `shortcuts list` | List staged candidates awaiting promotion |
+
+## Integration
+
+- **Reviewer (SKILL.md):** a new step runs `falsify verdicts` / `shortcuts
+  list` to surface failing procedures and staged shortcuts for action (patch,
+  promote, or dismiss). Keeps the reviewer thin; expensive work stays in the
+  curator.
+- **Curator:** `curator run` now (1) calls `outcomes index` (cheap incremental),
+  (2) calls `falsify run` to refresh verdicts + apply demotions, (3) writes
+  repaired `use_count`s to `.usage.json`. The existing decay-based memory
+  eviction is untouched.
+- **improve.py:** unchanged in mechanism; its "conflicting rules → retire the
+  loser" policy is the model for `falsify`'s consequence layer. (One
+  contradiction engine per artifact: improve.py owns AGENTS.md rules; falsify
+  owns skill verdicts. No duplication.)
+
+## Error Handling
+
+| Condition | Behaviour |
+|-----------|-----------|
+| `opencode.db` missing | `outcomes init` prints a message and exits 1 (like `search init`). |
+| `outcomes.db` missing on query | Treat as empty index; return empty lists, do not crash. |
+| Corrupt part JSON | Skip the part, log to `debug.log`, continue. |
+| Test suite / declared command times out | `verdict: inconclusive`, evidence notes the timeout. |
+| Declared command not in safe subset | `inconclusive` (never executed). |
+| Skill dir missing scripts/ | `method: none`, `verdict: inconclusive`. |
+
+## Edge Cases
+
+1. **A skill with both a test suite and a `verify:` block** — the test suite
+   wins (strongest claim); the declared block is noted but not run.
+2. **Non-deterministic tests** — a single fail is enough to demote (fail_count
+   reaches threshold on first failure). Pinned skills (`pinned: true` in
+   `.usage.json`) are exempt from auto-demote (flagged only), matching the
+   curator's existing pin exemption.
+3. **Roundabout with no terminal success** — recorded with `golden_command:
+   null`; surfaced as a pure-cost finding, never promoted.
+4. **`use_count` repair vs. manual edits** — the derived count is authoritative
+   (it reflects actual loads); manual edits to `use_count` are overwritten on
+   the next curator run.
+
+## Dependencies
+
+- **Python ≥3.11** (already required), stdlib only for all modules.
+- **python-slugify** (already a dep) where needed.
+- No new third-party dependencies. No embeddings, no vector store.
+
+## Build Order (dependency-aware)
+
+1. `outcomes.py` + tests (spine; both loops depend on it). **Freezes the
+   `OutcomeIndex` query API before step 2–3 start.**
+2. `falsify.py` + tests (Loop 1).
+3. `shortcuts.py` + tests (Loop 2).
+4. `autolearn.py` subparser wiring + `set_persona` `OUTCOMES_DB` path + curator
+   integration (single integration pass).
+5. inspector UI endpoints.
+
+Steps 2 and 3 are file-disjoint after step 1 freezes the `outcomes.py` API, and
+may be implemented by parallel subagents.
+
+## Related Documents
+
+- [High-Level Design](../../high-level-design.md) (Decisions 10–12, new feature rows)
+- [Certified Procedures EARS](./certified-procedures-EARS.md)
+- [Session Search LLD](../session-search/LLD.md) (the index pattern this mirrors; DD1/DD2/DD4)
+- [Skill Management LLD](../skill-management/LLD.md) (`.usage.json`, the reuse ledger)
+- [Review Agent LLD](../review-agent/LLD.md) (the signal taxonomy reused for `gt_strength` corrections)

--- a/docs/designs/certified-procedures/certified-procedures-EARS.md
+++ b/docs/designs/certified-procedures/certified-procedures-EARS.md
@@ -1,0 +1,100 @@
+# Certified Procedures - EARS Requirements
+
+**Spec**: `docs/designs/certified-procedures/LLD.md`
+EARS = Easy Approach to Requirements Syntax (`WHEN <trigger> THE SYSTEM SHALL <behavior>`).
+Code references use `@spec CP-<ID>` tags.
+
+## outcomes.py — shared spine
+
+### CP-OUT-001 (incremental index)
+**WHEN** the user runs `outcomes init` **THE SYSTEM SHALL** index `opencode.db`
+`part` rows newer than the last indexed `time_created`, dispatching on
+`json_extract(data,'$.type')` to `tool` and `step-finish` (ignoring all others),
+into `outcomes.db`, without writing to `opencode.db`.
+
+### CP-OUT-002 (full rebuild)
+**WHEN** the user runs `outcomes init --full` **THE SYSTEM SHALL** truncate
+`tool_outcome`, `step_cost`, and the `last_part_time` mark before re-indexing.
+
+### CP-OUT-003 (ground-truth classification)
+**WHEN** a tool part is indexed **THE SYSTEM SHALL** classify its ground-truth
+strength into `{4 test, 3 exit-code, 1 raw, 0 none}` and store it as
+`gt_strength`, preferring `state.metadata.exit` for bash exit codes, and where
+raw output (grep/read/edit) is never above 1. (The `2 correction` class — a user
+text correction within a window after the call — is **reserved for the deferred
+probabilistic layer** and is not assigned by the deterministic index.)
+
+### CP-OUT-004 (data-returning query API)
+**WHEN** a caller requests outcomes **THE SYSTEM SHALL** return structured rows
+from `outcomes.db` (not print them), so `falsify.py` and `shortcuts.py` can
+consume them without importing `autolearn.py`.
+
+### CP-OUT-005 (reuse-ledger derivation)
+**WHEN** `skill_use_counts()` is called **THE SYSTEM SHALL** return a
+`{skill_name: load_count}` map derived from `tool='skill'` part counts,
+independent of `.usage.json`.
+
+## falsify.py — Loop 1 (deterministic)
+
+### CP-FAL-001 (claim discovery)
+**WHEN** a skill is verified **THE SYSTEM SHALL** discover its strongest
+falsifiable claim as `test-suite` (if `scripts/test_*.py` exists) else
+`declared` (if SKILL.md frontmatter has a `verify:` block) else `none`.
+
+### CP-FAL-002 (deterministic verdict)
+**WHEN** a skill has a `test-suite` or `declared` claim **THE SYSTEM SHALL**
+execute it in the skill directory with a timeout and produce a `pass` / `fail`
+/ `inconclusive` verdict; a skill with no claim **SHALL** receive
+`inconclusive, method: none` and be left untouched.
+
+### CP-FAL-003 (bounded execution safety)
+**WHEN** a declared command is outside a safe subset (read-only commands + test
+runners, no network) **THE SYSTEM SHALL** return `inconclusive` rather than
+execute it.
+
+### CP-FAL-004 (consequence policy — deterministic)
+**WHEN** a skill's consecutive `fail` count reaches `falsify_fail_demote_after`
+**THE SYSTEM SHALL** set its `.usage.json` state to `stale` and flag it for
+patch, unless the skill is `pinned` (flagged only).
+
+### CP-FAL-005 (no probabilistic auto-demote)
+**WHEN** only correlation-based (probabilistic) evidence is available **THE
+SYSTEM SHALL** flag the skill for review and **SHALL NOT** auto-demote it.
+
+## shortcuts.py — Loop 2 (efficiency)
+
+### CP-SHO-001 (roundabout detection)
+**WHEN** a recent session contains a help-chain (>= `roundabout_help_depth`
+consecutive `--help`/`-h` probes before a working command) or an error-run (>=
+`roundabout_error_run` consecutive error tool calls before a completed one with
+the same tool) **THE SYSTEM SHALL** record it as a roundabout candidate with
+`cost_tokens` = the summed `step_cost` between the markers.
+
+### CP-SHO-002 (golden-path staging)
+**WHEN** a roundabout candidate has a terminal successful command **THE
+SYSTEM SHALL** stage it as a golden-path candidate with that command as
+`golden_command`; **WHEN** it has no terminal success **THE SYSTEM SHALL**
+record `golden_command: null` and never promote it.
+
+### CP-SHO-003 (promotion gated by verification)
+**WHEN** a golden-path candidate is considered for promotion to a skill/memory
+**THE SYSTEM SHALL** require a passing deterministic verification
+(`falsify.verify_skill`) of the direct command first; unverified candidates
+**SHALL NOT** be auto-promoted.
+
+### CP-SHO-004 (minimum-savings threshold)
+**WHEN** a candidate's `cost_tokens` is below `shortcut_promote_min_tokens`
+**THE SYSTEM SHALL** not surface it for promotion (noise filter).
+
+## integration
+
+### CP-INT-001 (curator wiring)
+**WHEN** `curator run` executes **THE SYSTEM SHALL** run `outcomes index`
+(incremental), then `falsify run`, then write derived `use_count`s back to
+`.usage.json`, in that order.
+
+### CP-INT-002 (inspector surface)
+**WHEN** the inspector UI is open **THE SYSTEM SHALL** expose
+`/api/procedures` (per-skill verdict + reuse count + method) and
+`/api/shortcuts` (staged candidates with estimated tokens-saved), and the
+overview **SHALL** include a failing-procedures count.

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -9,11 +9,17 @@
 > backends, multi-persona, plugin auto-sync) is shipped. Deferred: `rotate-key`,
 > interactive conflict resolution, salt auto-bootstrap, project-level persona mapping.
 >
-> **In flight** — *Memory Insight* (`docs/designs/memory-insight/`): replaces the
-> static 3000-char `memory.md` with a durable registry + dynamically composed
-> context view, adds Ebbinghaus-governed retention (embedding-free), a cross-session
-> recurring-preference (SW/EMA) shift detector, and a CLI-launchable inspector UI.
-> All components `planned`. See Decisions 8–9 and the Memory Insight LLD.
+> **Memory Insight** (`docs/designs/memory-insight/`) is **shipped**: the registry
+> (`memories.jsonl`), Ebbinghaus retention, the dynamic context composer, the
+> recurring-preference shift detector, and the inspector UI are all live and wired
+> into `autolearn.py` (see Decisions 8–9 and the Memory Insight LLD).
+>
+> **In flight** — *Certified Procedures* (`docs/designs/certified-procedures/`):
+> the Schema-harness-inspired ability to falsify autolearn's own skills against
+> ground-truth tool outcomes, and to shortcut roundabout workflows to a golden
+> path. Two co-equal loops (falsify + efficiency) on a shared `outcomes.py` spine
+> that indexes `opencode.db`'s tool-call + step-cost data the existing FTS5 index
+> excludes. See Decisions 10–12 and the Certified Procedures LLD.
 
 ## Problem Statement
 
@@ -160,7 +166,7 @@ Machine A                              Machine B
 - Generic S3/object store: No conflict detection, no per-file metadata, no auth built in.
 - Git-based sync: Merge conflicts on markdown bullet lists, requires git knowledge, no realtime.
 
-### Decision 8: Store/view separation — registry + dynamic context composition — _planned_
+### Decision 8: Store/view separation — registry + dynamic context composition — _shipped_
 
 **Choice**: Replace the single static, 3000-char-capped `memory.md` with two
 layers — a durable, unbounded `memories.jsonl` registry, and a per-session
@@ -183,7 +189,7 @@ gets the most useful (relevant + retained) tokens each session.
 - Embeddings for relevance: deferred — lexical Jaccard over topic tokens covers
   the recurring-preference case at zero dependency cost (see Decision 9).
 
-### Decision 9: Ebbinghaus-governed forgetting, embedding-free — _planned_
+### Decision 9: Ebbinghaus-governed forgetting, embedding-free — _shipped_
 
 **Choice**: Each memory carries a decaying retention score
 (`salience · e^(−λ·Δt) + σ·Σ(1/days_since_reinforcement)`); a record is evicted
@@ -204,6 +210,72 @@ relevance step alone.
   the recurring-preference detection that motivated the feature.
 - Hand-rolled FIFO retention (status quo): causes the staleness and orphans this
   decision set out to fix.
+
+### Decision 10: Falsify skills, not memories; against tool outcomes, not text — _in flight_
+
+**Choice**: Certified Procedures targets **skills** (autolearn's program-analog)
+and falsifies them against **ground-truth-bearing tool outcomes** indexed from
+`opencode.db`'s `part` table (`tool` / `step-finish` rows), which the existing
+FTS5 search index deliberately excludes (session-search DD4). It does **not**
+backtest prose memories against prose snippets.
+
+**Rationale**: The earlier "Certified Memory" concept was rejected on review.
+Schema's backtest is valuable because it is *verifiable* (run the program →
+compare to ground truth). A repo is not a closed deterministic system, so exact
+replay is impossible — but `opencode.db` *does* carry structured
+ground-truth-bearing evidence (106k+ tool parts incl. 2,485 errors; ~98k
+step-finish token ledgers; 1,394 skill-load parts). Prose-vs-prose backtesting
+retains none of Schema's verifiability and is polarity-blind and
+drift-confounding; backtesting skills against tool outcomes does. The critical
+epistemic rule: an outcome only falsifies where it carries a ground-truth bit
+(test result > exit code > user correction > raw output).
+
+**Alternatives considered**:
+- Backtest prose memories against FTS5 conversation text: rejected — the index
+  excludes tool outcomes by design, and lexical contradiction is unreliable.
+- A perfect repo simulator (true Schema `step()`): rejected — a repo is open and
+  non-deterministic; planning-inside-the-model is out of scope.
+
+### Decision 11: Two co-equal loops (falsify + efficiency) on one outcome spine — _in flight_
+
+**Choice**: Build the outcome index once (`outcomes.py`) and serve two loops:
+**Loop 1 (falsify)** verifies skills deterministically and auto-demotes
+failures; **Loop 2 (efficiency)** detects expensive roundabout tool sequences,
+extracts the golden path, and promotes it — gated by Loop 1 verification.
+
+**Rationale**: Falsification delivers *correctness* (procedures stay valid);
+the golden-path loop delivers *efficiency* (don't rediscover the direct
+invocation). They share the same substrate (the outcome index + step-cost
+ledger) and compose: Loop 2 proposes a shortcut, Loop 1 verifies it before
+promotion, so lucky one-off commands don't harden into bad shortcuts. Treating
+them co-equal matches the goal of "an opencode that gets more efficient over
+time," not just "tidier memory." Side benefit: indexing skill-load parts
+auto-repairs the dead `.usage.json` reuse ledger (`use_count` is currently never
+incremented).
+
+**Alternatives considered**:
+- Falsify-only, defer efficiency: cleaner sequencing but defers the
+  token-savings payoff that motivated the feature.
+- Efficiency-primary, falsify-secondary: inverts the safety layer; rejected
+  because ungated shortcut promotion is the failure mode Loop 1 prevents.
+
+### Decision 12: Deterministic falsification first; probabilistic is suggestion-only — _in flight_
+
+**Choice**: Loop 1 evaluates `test-suite` and `declared` claims
+deterministically and may auto-demote failures; correlation-based
+(skill-load → subsequent outcomes) falsification is deferred and, when added,
+is **suggestion-only — never auto-demote**.
+
+**Rationale**: Deterministic checks carry ground truth, so acting on them
+(auto-demote + flag) is safe. Probabilistic signals are drift-confounding and
+false-positive-prone; routing them around the Ebbinghaus grace period would, on
+present evidence, be net-negative. This honors the review finding that an
+automated "hygiene" loop on a noisy signal makes the system worse than no-op.
+
+**Alternatives considered**:
+- Probabilistic-first (covers all skills immediately): rejected — weaker signal
+  the review flagged; deterministic-first is the genuine Schema-grade path.
+- Auto-demote on correlation: rejected — unsafe on a noisy, drift-blind signal.
 
 ## Data Store Layout
 
@@ -257,11 +329,14 @@ Existing flat-layout installs are migrated to `personas/default/` automatically 
 | E2E-Encrypted Sync | shipped | Client-side AES-256-GCM, zero-knowledge server. Crypto, CLI (sync login/push/pull/status/export-key), plugin auto-sync. rotate-key + interactive pull deferred. | `autolearn.py` (sync), `sync-server/`, `sync-convex/`, `plugin/autolearn.js` |
 | Multi-Persona | shipped | Isolated knowledge stores per context (work/personal/OSS). Flat-to-personas migration is automatic and backward-compatible. | autolearn.py (persona) |
 | Backend-Agnostic Sync | shipped | Fastify+SQLite (bun:sqlite) and Convex HTTP Actions both implement the same REST API. CLI is backend-agnostic. | `sync-server/`, `sync-convex/` |
-| Memory Registry | planned | Durable unbounded `memories.jsonl` replacing the 3000-char `memory.md`; absorbs `strengths.json`; lazy legacy migration. | `registry.py`, `autolearn.py` |
-| Ebbinghaus Retention | planned | Decay + strengthen-on-access scoring; tiering (hot/warm/cold/evictable); grace-period eviction. Embedding-free. | `retention.py`, `autolearn.py` |
-| Context Composer | planned | Relevance × retention ranking into a soft char budget; emits `memory.context.md`; plugin regenerates on session start + after review. | `composer.py`, `plugin/autolearn.js` |
-| Recurring-Preference Detector | planned | Cross-session SW/EMA shift detector over lexical topic signatures; rising→candidate, falling→"learned". Embedding-free. | `shift.py`, `autolearn.py` |
-| Inspector UI | planned | CLI-launchable local web app to explore registry, retention curves, candidates, skills, activity. Stdlib-only server. | `inspector_server.py`, `autolearn.py` |
+| Memory Registry | shipped | Durable unbounded `memories.jsonl` replacing the 3000-char `memory.md`; absorbs `strengths.json`; lazy legacy migration. | `registry.py`, `autolearn.py` |
+| Ebbinghaus Retention | shipped | Decay + strengthen-on-access scoring; tiering (hot/warm/cold/evictable); grace-period eviction. Embedding-free. | `retention.py`, `autolearn.py` |
+| Context Composer | shipped | Relevance × retention ranking into a soft char budget; emits `memory.context.md`; plugin regenerates on session start + after review. | `composer.py`, `plugin/autolearn.js` |
+| Recurring-Preference Detector | shipped | Cross-session SW/EMA shift detector over lexical topic signatures; rising→candidate, falling→"learned". Embedding-free. | `shift.py`, `autolearn.py` |
+| Inspector UI | shipped | CLI-launchable local web app to explore registry, retention curves, candidates, skills, activity. Stdlib-only server. | `inspector_server.py`, `autolearn.py` |
+| Outcome Index | in flight | Indexes `opencode.db` tool-call + step-cost + skill-load parts the FTS5 index excludes; ground-truth-weighted; repairs `.usage.json` use_count. | `outcomes.py`, `autolearn.py` |
+| Procedure Falsification | in flight | Deterministic verification of skills (test-suite / declared claims); auto-demote + flag failures; probabilistic deferred as suggestion-only. | `falsify.py`, `autolearn.py` |
+| Golden-Path Shortcuts | in flight | Detects expensive roundabout tool sequences, extracts the direct invocation, promotes it gated by falsification. | `shortcuts.py`, `autolearn.py` |
 
 ## Risks and Mitigations
 

--- a/skills/autolearn-reviewer/scripts/autolearn.py
+++ b/skills/autolearn-reviewer/scripts/autolearn.py
@@ -53,6 +53,12 @@ import composer
 import shift
 import inspector_server
 
+# Certified Procedures subsystem (outcome index + falsify + shortcuts).
+# See docs/designs/certified-procedures/LLD.md.
+import outcomes
+import falsify
+import shortcuts
+
 # @spec KS-MEM-020
 DATA_HOME = Path(os.environ.get("AUTOLEARN_HOME", Path.home() / ".autolearn"))
 
@@ -80,6 +86,7 @@ MAX_USER_CHARS = 2000
 
 OPENCODE_DB = Path.home() / ".local" / "share" / "opencode" / "opencode.db"
 SEARCH_DB = ACTIVE_PERSONA_DIR / "search.db"
+OUTCOMES_DB = ACTIVE_PERSONA_DIR / "outcomes.db"  # Certified Procedures spine (persona-local)
 
 # Sync config and salt are shared across personas (not persona-specific).
 SYNC_CONFIG_FILE = DATA_HOME / "sync.yaml"
@@ -92,7 +99,7 @@ def set_persona(name: str) -> None:
     global ACTIVE_PERSONA, ACTIVE_PERSONA_DIR
     global MEMORY_FILE, USER_FILE, CONFIG_FILE, SKILLS_DIR, ARCHIVE_DIR
     global USAGE_FILE, CURATOR_STATE_FILE, OBSERVATIONS_FILE
-    global SEARCH_DB
+    global SEARCH_DB, OUTCOMES_DB
     ACTIVE_PERSONA = name
     ACTIVE_PERSONA_DIR = PERSONAS_DIR / name
     MEMORY_FILE = ACTIVE_PERSONA_DIR / "memory.md"
@@ -104,6 +111,7 @@ def set_persona(name: str) -> None:
     CURATOR_STATE_FILE = ACTIVE_PERSONA_DIR / ".curator_state.json"
     OBSERVATIONS_FILE = ACTIVE_PERSONA_DIR / "observations.jsonl"
     SEARCH_DB = ACTIVE_PERSONA_DIR / "search.db"
+    OUTCOMES_DB = ACTIVE_PERSONA_DIR / "outcomes.db"
 
 
 # @spec KS-MEM-001
@@ -238,6 +246,28 @@ def load_usage() -> dict:
 def save_usage(data: dict):
     ensure_dirs()
     USAGE_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+# @spec CP-OUT-005, CP-INT-001
+def repair_skill_use_counts() -> dict:
+    """Write skill load counts (derived from the outcome index) into .usage.json.
+
+    The ``use_count`` field is plumbed but never incremented today (skill-mgmt
+    LLD:91). The outcome index derives it from ``tool='skill'`` part counts,
+    which is authoritative for "times loaded in a recorded session".
+    """
+    usage = load_usage()
+    idx = outcomes.OutcomeIndex(OUTCOMES_DB, OPENCODE_DB)
+    counts = idx.skill_use_counts()
+    idx.close()
+    updated = 0
+    for name, meta in usage.items():
+        if name in counts and meta.get("use_count") != counts[name]:
+            meta["use_count"] = counts[name]
+            updated += 1
+    if updated:
+        save_usage(usage)
+    return {"updated": updated, "skills_with_loads": len(counts)}
 
 
 def load_config() -> dict:
@@ -760,19 +790,46 @@ def cmd_curator_run(args):
         if count >= escalation_threshold:
             escalation_candidates.append((rec.get("text", rec.get("id", "")), count))
 
+    # @spec CP-INT-001 — Certified Procedures orchestration (best-effort).
+    cp = {"indexed": None, "falsify": None, "usage_repaired": None}
+    try:
+        idx = outcomes.OutcomeIndex(OUTCOMES_DB, OPENCODE_DB)
+        cp["indexed"] = idx.index()
+        idx.close()
+    except Exception as exc:  # never let CP break the curator
+        cp["indexed"] = {"error": str(exc)}
+    try:
+        summary = falsify.verify_all(SKILLS_DIR, ACTIVE_PERSONA_DIR / falsify.VERDICTS_FILE)
+        usage = load_usage()
+        cons = falsify.apply_consequences(usage, summary["ledger"])
+        save_usage(usage)
+        cp["falsify"] = {k: summary[k] for k in ("pass", "fail", "inconclusive")}
+        cp["falsify"]["demoted"] = len(cons["demoted"])
+    except Exception as exc:
+        cp["falsify"] = {"error": str(exc)}
+    try:
+        cp["usage_repaired"] = repair_skill_use_counts()
+    except Exception as exc:
+        cp["usage_repaired"] = {"error": str(exc)}
+
     run_record = {
         "date": today.isoformat(),
         "transitions": transitions,
         "escalation_candidates": [
             {"entry": e, "strength": s} for e, s in escalation_candidates
         ],
+        "certified_procedures": cp,
     }
     state["last_run"] = today.isoformat()
     state["runs"].append(run_record)
     save_curator_state(state)
 
     total_transitions = sum(len(v) for v in transitions.values())
-    if total_transitions == 0 and not escalation_candidates:
+    cp_fail = cp.get("falsify", {})
+    cp_indexed = cp.get("indexed", {})
+    has_cp_signal = (isinstance(cp_fail, dict) and cp_fail.get("demoted")) or \
+                    (isinstance(cp_indexed, dict) and cp_indexed.get("gt_ge2"))
+    if total_transitions == 0 and not escalation_candidates and not has_cp_signal:
         print("Curator run complete: no transitions needed, no escalation candidates.")
     else:
         print("Curator run complete:")
@@ -784,6 +841,16 @@ def cmd_curator_run(args):
             for snippet, count in sorted(escalation_candidates, key=lambda x: -x[1]):
                 display = snippet[:80] + "..." if len(snippet) > 80 else snippet
                 print(f"    [{count}x] {display}")
+    # Certified Procedures summary (falsify demotions + reuse-ledger repair)
+    if isinstance(cp_fail, dict) and "pass" in cp_fail:
+        print(f"  procedures: {cp_fail.get('pass', 0)} pass, "
+              f"{cp_fail.get('fail', 0)} fail, {cp_fail.get('inconclusive', 0)} inconclusive"
+              + (f", {cp_fail['demoted']} demoted" if cp_fail.get('demoted') else ""))
+    if isinstance(cp_indexed, dict) and cp_indexed.get("gt_ge2") is not None:
+        print(f"  outcomes: indexed {cp_indexed.get('tool_parts', 0)} tool parts "
+              f"({cp_indexed.get('gt_ge2', 0)} ground-truth)")
+    if isinstance(cp.get("usage_repaired"), dict) and cp["usage_repaired"].get("updated"):
+        print(f"  reuse ledger: repaired {cp['usage_repaired']['updated']} skill use_counts")
 
 
 # @spec SM-LC-010
@@ -1847,6 +1914,26 @@ def main():
     topo_sub.add_parser("scan", help="Scan recent sessions for rising/falling topics")
     topo_sub.add_parser("candidates", help="List pending candidate preferences")
 
+    # --- Certified Procedures commands ---
+    oc = sub.add_parser("outcomes", help="Index opencode.db tool-call outcomes (Certified Procedures spine)", parents=[persona_parent])
+    oc_sub = oc.add_subparsers(dest="subcommand")
+    oc_init = oc_sub.add_parser("init", help="Build/update the outcome index from opencode.db")
+    oc_init.add_argument("--full", action="store_true", help="Full rebuild")
+    oc_sub.add_parser("status", help="Show outcome index size and coverage")
+
+    fal = sub.add_parser("falsify", help="Falsify skills against their claims (Loop 1)", parents=[persona_parent])
+    fal_sub = fal.add_subparsers(dest="subcommand")
+    fal_run = fal_sub.add_parser("run", help="Verify skills and apply consequences")
+    fal_run.add_argument("--id", default=None, help="Verify a single skill by name")
+    fal_run.add_argument("--dry-run", action="store_true", help="Report without mutating")
+    fal_sub.add_parser("verdicts", help="Print the per-skill verdict ledger")
+
+    sho = sub.add_parser("shortcuts", help="Detect roundabout workflows + golden paths (Loop 2)", parents=[persona_parent])
+    sho_sub = sho.add_subparsers(dest="subcommand")
+    sho_det = sho_sub.add_parser("detect", help="Scan recent sessions for roundabout paths")
+    sho_det.add_argument("--dry-run", action="store_true", help="Report without saving candidates")
+    sho_sub.add_parser("list", help="List staged golden-path candidates")
+
     args = parser.parse_args()
     if not args.command:
         parser.print_help()
@@ -1911,6 +1998,18 @@ def main():
         "topics": {
             "scan": cmd_topics_scan,
             "candidates": cmd_topics_candidates,
+        },
+        "outcomes": {
+            "init": outcomes.cmd_outcomes_init,
+            "status": outcomes.cmd_outcomes_status,
+        },
+        "falsify": {
+            "run": falsify.cmd_falsify_run,
+            "verdicts": falsify.cmd_falsify_verdicts,
+        },
+        "shortcuts": {
+            "detect": shortcuts.cmd_shortcuts_detect,
+            "list": shortcuts.cmd_shortcuts_list,
         },
     }
 

--- a/skills/autolearn-reviewer/scripts/falsify.py
+++ b/skills/autolearn-reviewer/scripts/falsify.py
@@ -1,0 +1,337 @@
+"""Falsify — Loop 1 of Certified Procedures. Verify skills deterministically.
+
+A skill is autolearn's program-analog. This module checks whether a skill's
+procedure still produces its claimed outcome, and demotes + flags failures.
+
+Deterministic-first scope (per Decision 12):
+  * ``test-suite`` claim — the skill ships ``scripts/test_*.py``. Run pytest;
+    exit 0 -> pass, exit 1 -> fail, anything else (collection error / missing
+    dep / timeout) -> inconclusive. Best-effort: a skill whose tests need deps
+    pytest can't see comes back inconclusive, not fail.
+  * ``declared`` claim   — SKILL.md frontmatter ``verify:`` block names the
+    exact command (+ expected exit). This is the robust path: the author
+    controls the environment. Only a safe command subset is executed.
+  * ``none``             — no claim -> inconclusive, untouched.
+
+Probabilistic (correlation-based) falsification is deferred and, when added,
+is suggestion-only — it never auto-demotes (CP-FAL-005).
+
+Spec: docs/designs/certified-procedures/LLD.md, certified-procedures-EARS.md (CP-FAL-*).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import outcomes
+
+DEFAULT_CONFIG = {
+    "falsify_fail_demote_after": 1,
+    "falsify_run_timeout_s": 120,
+}
+
+VERDICTS_FILE = "verdicts.json"
+
+# Safe-subset policy for a declared claim (CP-FAL-003). A declared claim must
+# be a test-runner invocation; arbitrary code execution / network / destructive
+# verbs are refused and the claim comes back inconclusive rather than executed.
+SAFE_DECLARED_TOKENS = outcomes.SAFE_DECLARED_TOKENS
+SAFE_DECLARED_DENY = outcomes.SAFE_DECLARED_DENY
+
+_TEST_CMD = "uv run --with pytest pytest scripts/ -q"
+
+
+# ---------------------------------------------------------------------------
+# Claim discovery
+# ---------------------------------------------------------------------------
+
+def _read_frontmatter_verify(skill_md: Path) -> dict | None:
+    """Minimal, stdlib-only parse of a ``verify:`` block from SKILL.md YAML
+    frontmatter. Returns {"command": str, "expect_exit": int} or None.
+
+    Only the narrow schema we define is supported; anything else -> None.
+    """
+    if not skill_md.exists():
+        return None
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.match(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", text, re.DOTALL)
+    if not m:
+        return None
+    fm = m.group(1)
+    # locate a top-level `verify:` block
+    i = fm.find("\nverify:")
+    if i < 0 and fm.startswith("verify:"):
+        i = -1  # block at very top
+    if i < 0 and not fm.startswith("verify:"):
+        return None
+    start = 0 if fm.startswith("verify:") else i + 1
+    lines = fm[start:].splitlines()
+    # lines[0] == "verify:"
+    if not lines or not lines[0].strip().rstrip(":").startswith("verify"):
+        return None
+    command = None
+    expect_exit = 0
+    in_block = False
+    for ln in lines[1:]:
+        if ln.startswith("  "):
+            in_block = True
+            s = ln.strip()
+            cm = re.match(r'command:\s*["\']?(.+?)["\']?\s*$', s)
+            if cm:
+                command = cm.group(1).strip()
+            em = re.match(r'expect_exit:\s*([0-9]+)\s*$', s)
+            if em:
+                expect_exit = int(em.group(1))
+        elif in_block:
+            break  # block ended
+    if not command:
+        return None
+    return {"command": command, "expect_exit": expect_exit}
+
+
+# @spec CP-FAL-001
+def claims_of(skill_dir: Path) -> list[dict]:
+    """Falsifiable claims, strongest first: test-suite > declared."""
+    claims: list[dict] = []
+    scripts_dir = skill_dir / "scripts"
+    if scripts_dir.is_dir():
+        tests = sorted(scripts_dir.glob("test_*.py"))
+        if tests:
+            claims.append({"method": "test-suite",
+                           "tests": [str(p.relative_to(skill_dir)) for p in tests]})
+    declared = _read_frontmatter_verify(skill_dir / "SKILL.md")
+    if declared:
+        claims.append({"method": "declared", **declared})
+    return claims
+
+
+def _is_safe_declared(command: str) -> bool:
+    """A declared verify command is safe iff it is a test-runner invocation and
+    contains no arbitrary-exec / network / destructive tokens (CP-FAL-003)."""
+    c = command.strip()
+    if SAFE_DECLARED_DENY.search(c):
+        return False
+    return any(tok in c for tok in SAFE_DECLARED_TOKENS)
+
+
+# @spec CP-FAL-002, CP-FAL-003
+def run_claim(claim: dict, *, cwd: Path, timeout: int) -> dict:
+    """Execute one claim. Returns {verdict, evidence, method}."""
+    method = claim["method"]
+    if method == "test-suite":
+        cmd = _TEST_CMD
+    elif method == "declared":
+        cmd = claim["command"]
+        if not _is_safe_declared(cmd):
+            return {"verdict": "inconclusive", "method": method,
+                    "evidence": "declared command outside safe subset; not executed"}
+    else:
+        return {"verdict": "inconclusive", "method": method, "evidence": "unknown method"}
+
+    try:
+        proc = subprocess.run(
+            cmd, shell=True, cwd=str(cwd), timeout=timeout,
+            capture_output=True, text=True,
+        )
+    except subprocess.TimeoutExpired:
+        return {"verdict": "inconclusive", "method": method,
+                "evidence": f"timed out after {timeout}s"}
+    except (OSError, ValueError) as exc:
+        return {"verdict": "inconclusive", "method": method,
+                "evidence": f"could not run: {exc}"}
+
+    rc = proc.returncode
+    tail = (proc.stderr or proc.stdout or "").strip().splitlines()
+    tail_str = "\n".join(tail[-6:])
+
+    if method == "test-suite":
+        # pytest exit codes: 0 pass, 1 fail, 2+ interrupted/internal/no-tests
+        if rc == 0:
+            return {"verdict": "pass", "method": method, "evidence": "test-suite green"}
+        if rc == 1:
+            return {"verdict": "fail", "method": method,
+                    "evidence": "test-suite reported failures" + (f":\n{tail_str}" if tail_str else "")}
+        return {"verdict": "inconclusive", "method": method,
+                "evidence": f"pytest exit {rc} (collection/dep error?)"
+                + (f":\n{tail_str}" if tail_str else "")}
+
+    # declared
+    expect = int(claim.get("expect_exit", 0))
+    if rc == expect:
+        return {"verdict": "pass", "method": method,
+                "evidence": f"exit {rc} == expected {expect}"}
+    return {"verdict": "fail", "method": method,
+            "evidence": f"exit {rc} != expected {expect}"
+            + (f":\n{tail_str}" if tail_str else "")}
+
+
+# @spec CP-FAL-002
+def verify_skill(skill_dir: Path, *, config: dict | None = None) -> dict:
+    """Verify one skill; return a verdict record (see VERDICTS_FILE schema)."""
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    claims = claims_of(skill_dir)
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+    if not claims:
+        return {"skill": skill_dir.name, "verdict": "inconclusive",
+                "method": "none", "evidence": "no falsifiable claim",
+                "checked_at": now}
+    # strongest claim first; run only it
+    res = run_claim(claims[0], cwd=skill_dir, timeout=int(cfg["falsify_run_timeout_s"]))
+    return {"skill": skill_dir.name, **res, "checked_at": now}
+
+
+# ---------------------------------------------------------------------------
+# Ledger + consequences
+# ---------------------------------------------------------------------------
+
+def _load_verdicts(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_verdicts(path: Path, data: dict) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _load_usage(skills_dir: Path) -> dict:
+    usage_file = skills_dir / ".usage.json"
+    if not usage_file.exists():
+        return {}
+    try:
+        return json.loads(usage_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_usage(skills_dir: Path, usage: dict) -> None:
+    usage_file = skills_dir / ".usage.json"
+    tmp = usage_file.with_suffix(usage_file.suffix + ".tmp")
+    tmp.write_text(json.dumps(usage, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(tmp, usage_file)
+
+
+# @spec CP-FAL-002
+def verify_all(skills_dir: Path, verdicts_path: Path, *,
+               config: dict | None = None, dry_run: bool = False,
+               only: str | None = None) -> dict:
+    """Verify every active skill; write the verdict ledger; return a summary."""
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    usage = _load_usage(skills_dir)
+    ledger = _load_verdicts(verdicts_path)
+    summary = {"pass": 0, "fail": 0, "inconclusive": 0, "demoted": 0}
+
+    skill_dirs = [d for d in sorted(skills_dir.iterdir())
+                  if d.is_dir() and (d / "SKILL.md").exists()]
+    for sd in skill_dirs:
+        name = sd.name
+        if only and name != only:
+            continue
+        meta = usage.get(name, {})
+        if meta.get("state") == "archived":
+            continue
+        prev = ledger.get(name, {})
+        verdict = verify_skill(sd, config=cfg)
+        # maintain consecutive fail_count (resets on pass; persists on inconclusive)
+        if verdict["verdict"] == "fail":
+            verdict["fail_count"] = int(prev.get("fail_count", 0)) + 1
+        elif verdict["verdict"] == "pass":
+            verdict["fail_count"] = 0
+        else:
+            verdict["fail_count"] = int(prev.get("fail_count", 0))
+        ledger[name] = verdict
+        summary[verdict["verdict"]] += 1
+
+    if not dry_run:
+        _save_verdicts(verdicts_path, ledger)
+    summary["ledger"] = ledger
+    return summary
+
+
+# @spec CP-FAL-004, CP-FAL-005
+def apply_consequences(usage: dict, ledger: dict, *, config: dict | None = None,
+                       dry_run: bool = False) -> dict:
+    """Demote skills whose deterministic fail_count reached the threshold.
+
+    Pinned skills are flagged only (never demoted). Probabilistic verdicts are
+    never produced by this module, so nothing here acts on weak evidence.
+    """
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    threshold = int(cfg["falsify_fail_demote_after"])
+    out = {"demoted": [], "flagged": []}
+    for name, v in ledger.items():
+        if v.get("verdict") != "fail":
+            continue
+        if int(v.get("fail_count", 0)) < threshold:
+            continue
+        meta = usage.setdefault(name, {})
+        pinned = bool(meta.get("pinned"))
+        flag = {"skill": name, "fail_count": v["fail_count"],
+                "evidence": v.get("evidence", "")[:200]}
+        if pinned:
+            out["flagged"].append(flag)
+            continue
+        if meta.get("state") != "stale":
+            if not dry_run:
+                meta["state"] = "stale"
+            out["demoted"].append(flag)
+        else:
+            out["flagged"].append(flag)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI handlers (thin; mirror retention.py)
+# ---------------------------------------------------------------------------
+
+def registry_for(args) -> Path:
+    home = Path(os.environ.get("AUTOLEARN_HOME", Path.home() / ".autolearn"))
+    persona = getattr(args, "persona", None) or "default"
+    return home / "personas" / persona
+
+
+def cmd_falsify_run(args):
+    persona_dir = registry_for(args)
+    skills_dir = persona_dir / "skills"
+    verdicts_path = persona_dir / VERDICTS_FILE
+    only = getattr(args, "id", None)
+    dry = bool(getattr(args, "dry_run", False))
+    summary = verify_all(skills_dir, verdicts_path, only=only, dry_run=dry)
+    usage = _load_usage(skills_dir)
+    cons = apply_consequences(usage, summary["ledger"], dry_run=dry)
+    if not dry:
+        _save_usage(skills_dir, usage)
+    print(f"Falsified skills: {summary['pass']} pass, {summary['fail']} fail, "
+          f"{summary['inconclusive']} inconclusive.")
+    if cons["demoted"]:
+        print(f"Demoted to stale ({'would' if dry else 'did'}):")
+        for d in cons["demoted"]:
+            print(f"  {d['skill']} (fails={d['fail_count']})")
+    if cons["flagged"]:
+        print("Flagged (pinned / already stale):")
+        for d in cons["flagged"]:
+            print(f"  {d['skill']} (fails={d['fail_count']})")
+
+
+def cmd_falsify_verdicts(args):
+    persona_dir = registry_for(args)
+    ledger = _load_verdicts(persona_dir / VERDICTS_FILE)
+    if not ledger:
+        print("No verdicts yet. Run `autolearn falsify run` first.")
+        return
+    for name in sorted(ledger):
+        v = ledger[name]
+        print(f"  {name}: {v['verdict']} ({v.get('method', '?')}) "
+              f"fails={v.get('fail_count', 0)} @ {v.get('checked_at', '?')}")

--- a/skills/autolearn-reviewer/scripts/inspector_server.py
+++ b/skills/autolearn-reviewer/scripts/inspector_server.py
@@ -94,6 +94,29 @@ def load_skills(pdir: Path) -> dict:
         return {}
 
 
+def load_verdicts(pdir: Path) -> dict:
+    """Per-skill falsification verdicts (Certified Procedures, Loop 1)."""
+    path = pdir / "verdicts.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def load_shortcuts(pdir: Path) -> list:
+    """Staged golden-path candidates (Certified Procedures, Loop 2)."""
+    path = pdir / "shortcuts.json"
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
 def load_activity(pdir: Path, n: int = 50) -> list[dict]:
     path = pdir / "observations.jsonl"
     if not path.exists():
@@ -138,12 +161,15 @@ def handle_request(method: str, path: str, body: bytes, persona_dir: Path):
                 tiers[t] += 1
         pending = load_candidates(persona_dir, "pending")
         learned = load_candidates(persona_dir, "learned")
+        verdicts = load_verdicts(persona_dir)
+        failing = sum(1 for v in verdicts.values() if v.get("verdict") == "fail")
         return json_response({
             "total": len([r for r in records if r.get("status") != "evicted"]),
             "tiers": tiers,
             "pending_candidates": len(pending),
             "learned": len(learned),
             "unscored": unscored,
+            "failing_procedures": failing,
         })
 
     if method == "GET" and route == "/api/memories":
@@ -181,6 +207,13 @@ def handle_request(method: str, path: str, body: bytes, persona_dir: Path):
 
     if method == "GET" and route == "/api/skills":
         return json_response(load_skills(persona_dir))
+
+    # @spec CP-INT-002 — Certified Procedures surfaces
+    if method == "GET" and route == "/api/procedures":
+        return json_response(load_verdicts(persona_dir))
+
+    if method == "GET" and route == "/api/shortcuts":
+        return json_response(load_shortcuts(persona_dir))
 
     if method == "GET" and route == "/api/activity":
         return json_response(load_activity(persona_dir))

--- a/skills/autolearn-reviewer/scripts/outcomes.py
+++ b/skills/autolearn-reviewer/scripts/outcomes.py
@@ -1,0 +1,453 @@
+"""Outcome index — the shared spine for Certified Procedures.
+
+Indexes ``opencode.db``'s ``part`` rows that the FTS5 search index deliberately
+excludes (session-search DD4): ``tool`` parts (command -> outcome), ``step-finish``
+parts (per-step token cost), and ``skill`` tool parts (skill-load -> session
+linkage). Writes to a persona-local ``outcomes.db`` (never to ``opencode.db``).
+
+Two loops consume this spine:
+  * ``falsify.py`` (Loop 1) — verify skills against ground-truth outcomes.
+  * ``shortcuts.py`` (Loop 2) — detect roundabout tool sequences + golden paths.
+
+Critical epistemic rule: an outcome only *falsifies* where it carries a
+ground-truth bit (test result > exit code > user correction > raw output). Raw
+structured output (grep/read/edit) is never above gt_strength 1.
+
+Spec: docs/designs/certified-procedures/LLD.md, certified-procedures-EARS.md (CP-OUT-*).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+OUTCOMES_DB_NAME = "outcomes.db"
+OUTPUT_PEEK_CHARS = 400
+
+DEFAULT_CONFIG = {
+    "outcomes_index_batch": 5000,
+}
+
+# Test-runner cues used by gt_strength classification (CP-OUT-003).
+TEST_RUNNERS = (
+    "pytest", "tox", "nox", "unittest", "npm test", "npm run test",
+    "yarn test", "pnpm test", "vitest", "jest", "mocha",
+    "go test", "cargo test", "rake test", "mix test", "dotnet test",
+    "gradle test", "mvn test", "pixi run test",
+)
+# Commands permitted for a *declared* falsification claim (CP-FAL-003). A
+# declared claim must be a test-runner invocation; arbitrary code execution
+# (`python -c`, `os.system`, network, destructive verbs) is refused and the
+# claim comes back inconclusive rather than executed.
+SAFE_DECLARED_TOKENS = TEST_RUNNERS
+SAFE_DECLARED_DENY = re.compile(
+    r"\b(rm|sudo|curl|wget|nc|ssh|scp|dd|mkfs|chmod\s|[>]&1|"
+    r"os\.system|subprocess|eval\(|exec\(|__import__|urllib|requests|socket|"
+    r"python[0-9.]*\s+-c)\b"
+)
+
+
+def _json(s: str | None) -> dict:
+    if not s:
+        return {}
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def _peek(s: str | None, n: int = OUTPUT_PEEK_CHARS) -> str:
+    if not s:
+        return ""
+    return s[:n]
+
+
+def is_test_command(tool: str, input_json: dict, output_peek: str) -> bool:
+    """Heuristic: does this tool call invoke a test runner?
+
+    Checks the *command* only (not output) so a non-test command whose output
+    happens to mention a runner is not misclassified.
+    """
+    if tool != "bash":
+        return False
+    cmd = input_json.get("command") if isinstance(input_json.get("command"), str) else ""
+    return any(t in cmd for t in TEST_RUNNERS)
+
+
+def exit_code_of(tool: str, status: str, input_json: dict, output_peek: str,
+                 meta_exit: int | None = None) -> int | None:
+    """Best-effort exit code. Prefers ``state.metadata.exit`` (where opencode
+    actually records it for bash); falls back to status/text cues."""
+    if meta_exit is not None:
+        return int(meta_exit)
+    if status != "completed":
+        return 1 if status == "error" else None
+    if tool != "bash":
+        return None
+    blob = f"{input_json.get('command','')} {output_peek}".lower()
+    for cue in ("exit code ", "exited with ", "exit: "):
+        i = blob.find(cue)
+        if i >= 0:
+            tail = blob[i + len(cue):].lstrip(" -:")
+            sign = 1
+            j = 0
+            if tail[:1] in "-":
+                sign = -1
+                j = 1
+            num = ""
+            while j < len(tail) and tail[j].isdigit():
+                num += tail[j]
+                j += 1
+            if num:
+                return sign * int(num)
+    return None
+
+
+# @spec CP-OUT-003
+def classify_gt(tool: str, status: str, input_json: dict, output_peek: str,
+                *, meta_exit: int | None = None) -> int:
+    """Ground-truth strength: 4 test | 3 exit-code | 2 correction | 1 raw | 0 none.
+
+    Note: ``2 correction`` (a user text correction within a window after the
+    call) is RESERVED for the deferred probabilistic layer and is NOT assigned
+    here — linking tool calls to subsequent user corrections requires text-part
+    windowing this index does not perform. This function therefore caps
+    tool-derived strength at 3. See EARS CP-OUT-003 + LLD.
+    """
+    if tool == "bash":
+        if is_test_command(tool, input_json, output_peek):
+            return 4
+        if meta_exit is not None or exit_code_of(tool, status, input_json,
+                                                 output_peek, meta_exit) is not None:
+            return 3
+        return 1
+    if status == "error":
+        return 3
+    if tool in ("read", "edit", "write", "glob", "grep"):
+        return 1
+    if tool == "skill":
+        return 0  # a skill load is linkage, not an outcome
+    return 1 if output_peek else 0
+
+
+class OutcomeIndex:
+    """A queryable index over opencode.db tool-call + step-cost parts.
+
+    Persona-local: ``outcomes.db`` lives under the persona dir and is never
+    synced (opencode.db is machine-local by nature; verdict provenance is
+    machine-local, not canonical).
+    """
+
+    def __init__(self, outcomes_db: Path, opencode_db: Path):
+        self.outcomes_db = Path(outcomes_db)
+        self.opencode_db = Path(opencode_db)
+        self.outcomes_db.parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(str(self.outcomes_db))
+        self.conn.row_factory = sqlite3.Row
+        self.conn.execute("PRAGMA journal_mode=WAL")
+        self.init_schema()  # idempotent; guarantees query methods work pre-index
+
+    def init_schema(self) -> None:
+        self.conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS index_state (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS tool_outcome (
+                part_id      TEXT PRIMARY KEY,
+                session_id   TEXT NOT NULL,
+                message_id   TEXT NOT NULL,
+                seq          INTEGER NOT NULL,
+                time_created INTEGER NOT NULL,
+                tool         TEXT NOT NULL,
+                status       TEXT NOT NULL,
+                skill_name   TEXT,
+                input_json   TEXT,
+                output_peek  TEXT,
+                gt_strength  INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS to_session_seq ON tool_outcome (session_id, seq);
+            CREATE INDEX IF NOT EXISTS to_skill ON tool_outcome (skill_name);
+            CREATE INDEX IF NOT EXISTS to_tool_status ON tool_outcome (tool, status);
+
+            CREATE TABLE IF NOT EXISTS step_cost (
+                part_id      TEXT PRIMARY KEY,
+                session_id   TEXT NOT NULL,
+                seq          INTEGER NOT NULL,
+                time_created INTEGER NOT NULL,
+                reason       TEXT,
+                tokens_in    INTEGER NOT NULL DEFAULT 0,
+                tokens_out   INTEGER NOT NULL DEFAULT 0,
+                tokens_reasoning INTEGER NOT NULL DEFAULT 0,
+                cache_read   INTEGER NOT NULL DEFAULT 0,
+                cache_write  INTEGER NOT NULL DEFAULT 0,
+                cost         REAL NOT NULL DEFAULT 0
+            );
+            CREATE INDEX IF NOT EXISTS sc_session_seq ON step_cost (session_id, seq);
+            """
+        )
+        self.conn.commit()
+
+    def _last_mark(self) -> tuple[int, str]:
+        """Return (last_time, last_part_id) — a composite key so parts sharing
+        a millisecond timestamp are not skipped across runs."""
+        row = self.conn.execute(
+            "SELECT value FROM index_state WHERE key = 'last_part_time'"
+        ).fetchone()
+        if not row:
+            return (0, "")
+        t, _, pid = str(row["value"]).partition("|")
+        try:
+            return (int(t), pid)
+        except ValueError:
+            return (0, "")
+
+    def _set_mark(self, ts: int, pid: str) -> None:
+        self.conn.execute(
+            "INSERT INTO index_state(key, value) VALUES('last_part_time', ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            [f"{ts}|{pid}"],
+        )
+
+    def _opencode_conn(self) -> sqlite3.Connection | None:
+        if not self.opencode_db.exists():
+            return None
+        c = sqlite3.connect(f"file:{self.opencode_db}?mode=ro", uri=True)
+        c.row_factory = sqlite3.Row
+        return c
+
+    # @spec CP-OUT-001, CP-OUT-002
+    def index(self, *, full: bool = False, config: dict | None = None) -> dict:
+        """Incremental high-water-mark index of opencode.db part rows.
+
+        Returns counters: {tool_parts, step_parts, skill_loads, gt_ge2, skipped, errors}.
+        """
+        cfg = {**DEFAULT_CONFIG, **(config or {})}
+        self.init_schema()
+
+        # Hoist the source-DB check ABOVE any --full truncation so a missing/
+        # moved opencode.db can never wipe an existing index (data-loss guard).
+        db = self._opencode_conn()
+        if db is None:
+            return {"tool_parts": 0, "step_parts": 0, "skill_loads": 0,
+                    "gt_ge2": 0, "skipped": 0, "errors": 0, "no_opencode_db": True}
+
+        if full:
+            self.conn.execute("DELETE FROM tool_outcome")
+            self.conn.execute("DELETE FROM step_cost")
+            self.conn.execute("DELETE FROM index_state WHERE key = 'last_part_time'")
+            self.conn.commit()
+
+        last_time, last_id = self._last_mark()
+        batch = int(cfg["outcomes_index_batch"])
+        summary = {"tool_parts": 0, "step_parts": 0, "skill_loads": 0,
+                   "gt_ge2": 0, "skipped": 0, "errors": 0}
+        high_time, high_id = last_time, last_id
+
+        rows = db.execute(
+            "SELECT p.id AS part_id, p.session_id, p.message_id, "
+            "p.time_created, p.data AS data "
+            "FROM part p "
+            "WHERE p.time_created > ? OR (p.time_created = ? AND p.id > ?) "
+            "ORDER BY p.time_created ASC, p.id ASC",
+            [last_time, last_time, last_id],
+        )
+
+        tool_rows: list[tuple] = []
+        step_rows: list[tuple] = []
+
+        for r in rows:
+            data = _json(r["data"])
+            ptype = data.get("type")
+            ts = int(r["time_created"])
+            pid = r["part_id"]
+            # cursor is ordered (time, id) ASC, so each row advances the mark
+            high_time, high_id = ts, pid
+            session_id = r["session_id"]
+            message_id = r["message_id"]
+            if ptype == "step-finish":
+                tokens = data.get("tokens") or {}
+                step_rows.append((
+                    pid, session_id, ts, ts, data.get("reason"),
+                    int(tokens.get("input") or 0), int(tokens.get("output") or 0),
+                    int(tokens.get("reasoning") or 0),
+                    int((tokens.get("cache") or {}).get("read") or 0),
+                    int((tokens.get("cache") or {}).get("write") or 0),
+                    float(data.get("cost") or 0.0),
+                ))
+                summary["step_parts"] += 1
+            elif ptype == "tool":
+                state = data.get("state") or {}
+                status = state.get("status") or "completed"
+                inp = state.get("input") or {}
+                inp_json = json.dumps(inp, ensure_ascii=False)
+                metadata = state.get("metadata") or {}
+                meta_exit = metadata.get("exit")
+                out = state.get("output")
+                peek = _peek(out if isinstance(out, str) else json.dumps(out, ensure_ascii=False))
+                tool = data.get("tool") or "unknown"
+                skill_name = inp.get("name") if tool == "skill" else None
+                gt = classify_gt(tool, status, inp, peek, meta_exit=meta_exit)
+                tool_rows.append((
+                    pid, session_id, message_id, ts, ts, tool, status,
+                    skill_name, inp_json, peek, gt,
+                ))
+                summary["tool_parts"] += 1
+                if tool == "skill":
+                    summary["skill_loads"] += 1
+                if gt >= 2:
+                    summary["gt_ge2"] += 1
+            else:
+                summary["skipped"] += 1
+
+            if len(tool_rows) + len(step_rows) >= batch:
+                self._flush(tool_rows, step_rows)
+                self._set_mark(high_time, high_id)
+                tool_rows, step_rows = [], []
+
+        self._flush(tool_rows, step_rows)
+        self._set_mark(high_time, high_id)
+        db.close()
+        return summary
+
+    def _flush(self, tool_rows: list[tuple], step_rows: list[tuple]) -> None:
+        if tool_rows:
+            self.conn.executemany(
+                "INSERT OR REPLACE INTO tool_outcome "
+                "(part_id, session_id, message_id, seq, time_created, tool, status, "
+                " skill_name, input_json, output_peek, gt_strength) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                tool_rows,
+            )
+        if step_rows:
+            self.conn.executemany(
+                "INSERT OR REPLACE INTO step_cost "
+                "(part_id, session_id, seq, time_created, reason, tokens_in, tokens_out, "
+                " tokens_reasoning, cache_read, cache_write, cost) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                step_rows,
+            )
+        self.conn.commit()
+
+    # -- query API (data-returning; CP-OUT-004) ---------------------------
+
+    def list_tool_outcomes(self, *, session_id: str | None = None,
+                           tool: str | None = None, skill: str | None = None,
+                           min_gt: int = 0, limit: int | None = None) -> list[dict]:
+        sql = ("SELECT part_id, session_id, message_id, seq, time_created, tool, "
+               "status, skill_name, input_json, output_peek, gt_strength "
+               "FROM tool_outcome WHERE 1=1")
+        params: list = []
+        if session_id is not None:
+            sql += " AND session_id = ?"
+            params.append(session_id)
+        if tool is not None:
+            sql += " AND tool = ?"
+            params.append(tool)
+        if skill is not None:
+            sql += " AND skill_name = ?"
+            params.append(skill)
+        if min_gt:
+            sql += " AND gt_strength >= ?"
+            params.append(min_gt)
+        sql += " ORDER BY session_id, seq, part_id"
+        if limit:
+            sql += " LIMIT ?"
+            params.append(limit)
+        return [dict(r) for r in self.conn.execute(sql, params)]
+
+    def session_sequences(self, session_id: str) -> list[dict]:
+        """Ordered tool_outcome rows for a session (for roundabout detection)."""
+        return self.list_tool_outcomes(session_id=session_id)
+
+    def recent_sessions(self, limit: int = 50) -> list[str]:
+        rows = self.conn.execute(
+            "SELECT session_id FROM tool_outcome "
+            "GROUP BY session_id "
+            "ORDER BY MAX(time_created) DESC LIMIT ?",
+            [limit],
+        ).fetchall()
+        return [r["session_id"] for r in rows]
+
+    # @spec CP-OUT-005
+    def skill_use_counts(self) -> dict[str, int]:
+        """{skill_name: load_count} derived from tool='skill' part counts.
+
+        Authoritative source for repairing .usage.json use_count.
+        """
+        rows = self.conn.execute(
+            "SELECT skill_name, COUNT(*) AS c FROM tool_outcome "
+            "WHERE tool='skill' AND skill_name IS NOT NULL "
+            "GROUP BY skill_name"
+        ).fetchall()
+        return {r["skill_name"]: int(r["c"]) for r in rows}
+
+    def status(self) -> dict:
+        def count(sql: str) -> int:
+            return int(self.conn.execute(sql).fetchone()[0])
+        tool_total = count("SELECT COUNT(*) FROM tool_outcome")
+        step_total = count("SELECT COUNT(*) FROM step_cost")
+        gt_hist = {str(r["gt"]): int(r["c"]) for r in self.conn.execute(
+            "SELECT gt_strength AS gt, COUNT(*) AS c FROM tool_outcome GROUP BY gt_strength"
+        ).fetchall()}
+        last, _ = self._last_mark()
+        last_iso = datetime.fromtimestamp(last / 1000).strftime("%Y-%m-%d %H:%M") if last else "never"
+        return {
+            "tool_parts": tool_total,
+            "step_parts": step_total,
+            "skill_loads": count("SELECT COUNT(*) FROM tool_outcome WHERE tool='skill'"),
+            "gt_histogram": gt_hist,
+            "last_indexed": last_iso,
+            "outcomes_db": str(self.outcomes_db),
+        }
+
+    def close(self) -> None:
+        try:
+            self.conn.close()
+        except sqlite3.Error:
+            pass
+
+
+def registry_for(args) -> Path:
+    """Resolve the persona dir for a CLI invocation (mirrors retention.registry_for)."""
+    home = Path(os.environ.get("AUTOLEARN_HOME", Path.home() / ".autolearn"))
+    persona = getattr(args, "persona", None) or "default"
+    return home / "personas" / persona
+
+
+def _opencode_db_path() -> Path:
+    return Path.home() / ".local" / "share" / "opencode" / "opencode.db"
+
+
+def cmd_outcomes_init(args):
+    persona_dir = registry_for(args)
+    idx = OutcomeIndex(persona_dir / OUTCOMES_DB_NAME, _opencode_db_path())
+    if getattr(args, "full", False):
+        print("Clearing existing outcome index for full rebuild...")
+    summary = idx.index(full=bool(getattr(args, "full", False)))
+    if summary.get("no_opencode_db"):
+        print(f"OpenCode database not found at {_opencode_db_path()}")
+        idx.close()
+        raise SystemExit(1)
+    print(f"Indexed {summary['tool_parts']} tool parts, "
+          f"{summary['step_parts']} step-cost parts "
+          f"({summary['skill_loads']} skill loads).")
+    print(f"Ground-truth outcomes (gt>=2): {summary['gt_ge2']}")
+    idx.close()
+
+
+def cmd_outcomes_status(args):
+    persona_dir = registry_for(args)
+    idx = OutcomeIndex(persona_dir / OUTCOMES_DB_NAME, _opencode_db_path())
+    s = idx.status()
+    print(f"Outcome index: {s['outcomes_db']}")
+    print(f"  Tool parts: {s['tool_parts']}")
+    print(f"  Step-cost parts: {s['step_parts']}")
+    print(f"  Skill loads: {s['skill_loads']}")
+    print(f"  Ground-truth histogram: {s['gt_histogram']}")
+    print(f"  Last indexed: {s['last_indexed']}")
+    idx.close()

--- a/skills/autolearn-reviewer/scripts/shortcuts.py
+++ b/skills/autolearn-reviewer/scripts/shortcuts.py
@@ -1,0 +1,264 @@
+"""Shortcuts — Loop 2 of Certified Procedures. Detect roundabout workflows;
+extract the golden path; gate promotion on falsification.
+
+Schema's efficiency gain came from "plan inside the certified model for free":
+pay the discovery cost once, then reuse. The autolearn analog is: the agent
+spends tokens rediscovering a CLI invocation each session; capture the direct
+("golden") command once and reuse it. This module detects that rediscovery from
+recorded tool-call sequences, and hands candidates to the existing skill/memory
+capture path — but only after ``falsify`` confirms the direct command still
+works (CP-SHO-003), so lucky one-off commands don't harden into bad shortcuts.
+
+Two roundabout shapes are detected:
+  * ``help-chain`` — >= N consecutive --help/-h probes before a working command.
+  * ``error-run``  — >= M consecutive error tool calls before a completed call
+                     with the same tool.
+
+Cost is measured in real tokens from the ``step_cost`` ledger (the data the FTS5
+index throws away).
+
+Spec: docs/designs/certified-procedures/LLD.md, certified-procedures-EARS.md (CP-SHO-*).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import falsify
+import outcomes
+
+DEFAULT_CONFIG = {
+    "roundabout_help_depth": 2,
+    "roundabout_error_run": 3,
+    "roundabout_recent_sessions": 50,
+    "shortcut_promote_min_tokens": 2000,
+    "shortcut_verify_timeout_s": 120,
+}
+
+CANDIDATES_FILE = "shortcuts.json"
+
+
+# ---------------------------------------------------------------------------
+# Sequence helpers
+# ---------------------------------------------------------------------------
+
+def _command_of(row: dict) -> str | None:
+    try:
+        inp = json.loads(row.get("input_json") or "{}")
+    except (json.JSONDecodeError, TypeError):
+        inp = {}
+    cmd = inp.get("command")
+    return cmd if isinstance(cmd, str) else None
+
+
+def _first_word(command: str | None) -> str | None:
+    if not command:
+        return None
+    return command.strip().split()[0] if command.strip() else None
+
+
+def _is_help_probe(row: dict) -> bool:
+    if row.get("tool") != "bash":
+        return False
+    cmd = (_command_of(row) or "").lower()
+    if "--help" in cmd:
+        return True
+    # bare "foo -h" but not "foo -help-ish"
+    return bool(re.search(r"(^|\s)-h(\s|$)", cmd))
+
+
+def _is_error(row: dict) -> bool:
+    return row.get("status") == "error"
+
+
+# @spec CP-SHO-002
+def _help_chains(session_id: str, rows: list[dict], config: dict) -> list[dict]:
+    """Help-chains: >= N consecutive --help probes. The golden command is the
+    first *completed* call after the run that shares a first token with a probe
+    (else None — a pure-cost finding, never promoted)."""
+    depth = int(config["roundabout_help_depth"])
+    out: list[dict] = []
+    i, n = 0, len(rows)
+    while i < n:
+        if _is_help_probe(rows[i]):
+            j = i
+            while j < n and _is_help_probe(rows[j]):
+                j += 1
+            run_len = j - i
+            if run_len >= depth:
+                probe_firsts = {_first_word(_command_of(r)) for r in rows[i:j]}
+                probe_firsts.discard(None)
+                golden = None
+                gtool = "bash"
+                end_seq = int(rows[j - 1]["seq"])
+                if j < n and rows[j].get("status") == "completed":
+                    gcmd = _command_of(rows[j])
+                    if gcmd and _first_word(gcmd) in probe_firsts:
+                        golden = gcmd
+                        gtool = rows[j].get("tool", "bash")
+                        end_seq = int(rows[j]["seq"])
+                out.append({
+                    "session_id": session_id, "kind": "help-chain",
+                    "start_seq": int(rows[i]["seq"]), "end_seq": end_seq,
+                    "tool": gtool, "golden_command": golden,
+                    "run_length": run_len,
+                })
+            i = j
+        else:
+            i += 1
+    return out
+
+
+# @spec CP-SHO-002
+def _error_runs(session_id: str, rows: list[dict], config: dict) -> list[dict]:
+    """Error-runs: >= M consecutive error calls. The golden command is the first
+    *completed* call after the run with the same tool (else None)."""
+    run = int(config["roundabout_error_run"])
+    out: list[dict] = []
+    i, n = 0, len(rows)
+    while i < n:
+        if _is_error(rows[i]):
+            j = i
+            while j < n and _is_error(rows[j]):
+                j += 1
+            run_len = j - i
+            if run_len >= run:
+                err_tool = rows[i].get("tool")
+                golden = None
+                gtool = err_tool
+                end_seq = int(rows[j - 1]["seq"])
+                if (j < n and rows[j].get("status") == "completed"
+                        and rows[j].get("tool") == err_tool):
+                    golden = _command_of(rows[j])
+                    gtool = rows[j].get("tool", err_tool)
+                    end_seq = int(rows[j]["seq"])
+                out.append({
+                    "session_id": session_id, "kind": "error-run",
+                    "start_seq": int(rows[i]["seq"]), "end_seq": end_seq,
+                    "tool": gtool, "golden_command": golden,
+                    "run_length": run_len,
+                })
+            i = j
+        else:
+            i += 1
+    return out
+
+
+# @spec CP-SHO-001
+def session_token_cost(index: outcomes.OutcomeIndex, session_id: str,
+                       start_seq: int, end_seq: int) -> int:
+    """Tokens (in+out+reasoning) spent on step_cost rows between two seq markers."""
+    row = index.conn.execute(
+        "SELECT COALESCE(SUM(tokens_in + tokens_out + tokens_reasoning), 0) AS s "
+        "FROM step_cost WHERE session_id = ? AND seq BETWEEN ? AND ?",
+        [session_id, start_seq, end_seq],
+    ).fetchone()
+    return int(row["s"]) if row else 0
+
+
+# @spec CP-SHO-001
+def detect_roundabouts(index: outcomes.OutcomeIndex, *, config: dict | None = None) -> list[dict]:
+    """Scan recent sessions for help-chain and error-run roundabouts.
+
+    Each candidate carries ``cost_tokens`` (the wasted discovery spend) and
+    ``golden_command`` (the direct invocation that worked, or None).
+    """
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    recent = int(cfg["roundabout_recent_sessions"])
+    cands: list[dict] = []
+    for sid in index.recent_sessions(recent):
+        rows = index.session_sequences(sid)
+        found = _help_chains(sid, rows, cfg) + _error_runs(sid, rows, cfg)
+        for c in found:
+            c["cost_tokens"] = session_token_cost(index, sid, c["start_seq"], c["end_seq"])
+            cands.append(c)
+    # most expensive first
+    cands.sort(key=lambda c: c.get("cost_tokens", 0), reverse=True)
+    return cands
+
+
+# @spec CP-SHO-003 (promotion gated by verification)
+def verify_candidate(candidate: dict, *, config: dict | None = None,
+                     cwd: Path | None = None) -> dict:
+    """Deterministically verify a candidate's golden command before promotion.
+
+    Builds a declared claim from ``golden_command`` and runs it through
+    ``falsify.run_claim`` (safe-subset enforced). Candidates whose golden
+    command is unsafe or absent come back inconclusive and are not promoted.
+    """
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    cmd = candidate.get("golden_command")
+    if not cmd:
+        return {"verdict": "inconclusive", "reason": "no golden command"}
+    claim = {"method": "declared", "command": cmd, "expect_exit": 0}
+    return falsify.run_claim(claim, cwd=cwd or Path.cwd(),
+                             timeout=int(cfg["shortcut_verify_timeout_s"]))
+
+
+# @spec CP-SHO-004
+def promotable(candidates: list[dict], *, config: dict | None = None) -> list[dict]:
+    """Filter to candidates worth surfacing for promotion (min token savings)."""
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    floor = int(cfg["shortcut_promote_min_tokens"])
+    return [c for c in candidates
+            if c.get("golden_command") and int(c.get("cost_tokens", 0)) >= floor]
+
+
+# ---------------------------------------------------------------------------
+# Persistence + CLI
+# ---------------------------------------------------------------------------
+
+def _load(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def _save(path: Path, cands: list[dict]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(cands, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def registry_for(args) -> Path:
+    home = Path(os.environ.get("AUTOLEARN_HOME", Path.home() / ".autolearn"))
+    persona = getattr(args, "persona", None) or "default"
+    return home / "personas" / persona
+
+
+def cmd_shortcuts_detect(args):
+    persona_dir = registry_for(args)
+    idx = outcomes.OutcomeIndex(persona_dir / outcomes.OUTCOMES_DB_NAME,
+                                outcomes._opencode_db_path())
+    idx.init_schema()
+    cands = detect_roundabouts(idx)
+    dry = bool(getattr(args, "dry_run", False))
+    prom = promotable(cands)
+    if not dry:
+        _save(persona_dir / CANDIDATES_FILE, cands)
+    print(f"Detected {len(cands)} roundabout candidates "
+          f"({len(prom)} worth promoting, >= {DEFAULT_CONFIG['shortcut_promote_min_tokens']} tok).")
+    for c in cands[:15]:
+        cmd = (c.get("golden_command") or "<none>")[:70]
+        print(f"  [{c['kind']}] {c['cost_tokens']} tok  tool={c['tool']}  golden={cmd}")
+    idx.close()
+
+
+def cmd_shortcuts_list(args):
+    persona_dir = registry_for(args)
+    cands = _load(persona_dir / CANDIDATES_FILE)
+    if not cands:
+        print("No shortcut candidates. Run `autolearn shortcuts detect` first.")
+        return
+    prom = promotable(cands)
+    print(f"{len(cands)} candidates ({len(prom)} promotable):")
+    for c in cands:
+        mark = "*" if c in prom else " "
+        cmd = (c.get("golden_command") or "<none>")[:70]
+        print(f" {mark} [{c['kind']}] {c['cost_tokens']} tok  tool={c['tool']}  golden={cmd}")

--- a/skills/autolearn-reviewer/scripts/test_falsify.py
+++ b/skills/autolearn-reviewer/scripts/test_falsify.py
@@ -1,0 +1,229 @@
+# /// script
+# dependencies = ["pytest"]
+# ///
+"""Tests for falsify.py — Loop 1 (deterministic procedure falsification)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import falsify
+
+
+# ---------------------------------------------------------------------------
+# Claim discovery (CP-FAL-001)
+# ---------------------------------------------------------------------------
+
+def test_claims_test_suite_detected(tmp_path):
+    skill = tmp_path / "my-skill"
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "scripts" / "test_foo.py").write_text("def test_x(): assert 1")
+    (skill / "SKILL.md").write_text("---\nname: my-skill\n---\n# My Skill\n")
+    claims = falsify.claims_of(skill)
+    assert claims and claims[0]["method"] == "test-suite"
+
+
+def test_claims_declared_from_frontmatter(tmp_path):
+    skill = tmp_path / "declared-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\n"
+        "name: declared-skill\n"
+        "verify:\n"
+        "  command: \"pytest -q\"\n"
+        "  expect_exit: 0\n"
+        "---\n# Declared\n"
+    )
+    claims = falsify.claims_of(skill)
+    assert any(c["method"] == "declared" for c in claims)
+    d = next(c for c in claims if c["method"] == "declared")
+    assert d["command"] == "pytest -q"
+    assert d["expect_exit"] == 0
+
+
+def test_claims_none_when_nothing_falsifiable(tmp_path):
+    skill = tmp_path / "prose-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: prose-skill\n---\n# Prose only\n")
+    assert falsify.claims_of(skill) == []
+
+
+def test_test_suite_ranked_above_declared(tmp_path):
+    skill = tmp_path / "both"
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "scripts" / "test_a.py").write_text("def test_a(): assert 1")
+    (skill / "SKILL.md").write_text(
+        "---\nname: both\nverify:\n  command: \"pytest -q\"\n---\n# Both\n"
+    )
+    claims = falsify.claims_of(skill)
+    assert claims[0]["method"] == "test-suite"
+
+
+# ---------------------------------------------------------------------------
+# Declared-claim execution + safety (CP-FAL-002, CP-FAL-003)
+# ---------------------------------------------------------------------------
+
+def test_run_declared_pass(tmp_path):
+    (tmp_path / "test_ok.py").write_text("def test_ok(): assert True\n")
+    res = falsify.run_claim(
+        {"method": "declared", "command": "uv run --with pytest pytest test_ok.py -q",
+         "expect_exit": 0},
+        cwd=tmp_path, timeout=120,
+    )
+    assert res["verdict"] == "pass"
+
+
+def test_run_declared_fail_on_wrong_exit(tmp_path):
+    (tmp_path / "test_bad.py").write_text("def test_bad(): assert False\n")
+    res = falsify.run_claim(
+        {"method": "declared", "command": "uv run --with pytest pytest test_bad.py -q",
+         "expect_exit": 0},
+        cwd=tmp_path, timeout=120,
+    )
+    assert res["verdict"] == "fail"
+
+
+def test_run_declared_unsafe_command_is_inconclusive(tmp_path):
+    res = falsify.run_claim(
+        {"method": "declared", "command": "rm -rf /", "expect_exit": 0},
+        cwd=tmp_path, timeout=10,
+    )
+    assert res["verdict"] == "inconclusive"
+    assert "safe subset" in res["evidence"]
+
+
+def test_run_declared_arbitrary_code_exec_is_inconclusive(tmp_path):
+    # contains a test-runner token but hides destructive code in `python -c`
+    res = falsify.run_claim(
+        {"method": "declared",
+         "command": "uv run --with pytest python -c \"import shutil; shutil.rmtree('/tmp/x')\"",
+         "expect_exit": 0},
+        cwd=tmp_path, timeout=10,
+    )
+    assert res["verdict"] == "inconclusive"
+
+
+def test_run_declared_network_command_is_inconclusive(tmp_path):
+    res = falsify.run_claim(
+        {"method": "declared", "command": "curl https://example.com", "expect_exit": 0},
+        cwd=tmp_path, timeout=10,
+    )
+    assert res["verdict"] == "inconclusive"
+
+
+# ---------------------------------------------------------------------------
+# verify_skill + verdicts (CP-FAL-002)
+# ---------------------------------------------------------------------------
+
+def test_verify_skill_no_claim_is_inconclusive(tmp_path):
+    skill = tmp_path / "prose"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: prose\n---\n# Prose\n")
+    v = falsify.verify_skill(skill)
+    assert v["verdict"] == "inconclusive"
+    assert v["method"] == "none"
+
+
+def test_verify_skill_declared_fail_records(tmp_path):
+    skill = tmp_path / "bad"
+    skill.mkdir()
+    (skill / "test_bad.py").write_text("def test_bad(): assert False\n")
+    (skill / "SKILL.md").write_text(
+        "---\nname: bad\nverify:\n  command: \"uv run --with pytest pytest test_bad.py -q\"\n---\n# Bad\n"
+    )
+    v = falsify.verify_skill(skill)
+    assert v["verdict"] == "fail"
+    assert v["skill"] == "bad"
+
+
+# ---------------------------------------------------------------------------
+# verify_all ledger + consequences (CP-FAL-002, CP-FAL-004)
+# ---------------------------------------------------------------------------
+
+def _make_skills_dir(tmp_path) -> tuple[Path, Path]:
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    # good: passes declared (real test file)
+    good = skills / "good"
+    good.mkdir()
+    (good / "test_ok.py").write_text("def test_ok(): assert True\n")
+    (good / "SKILL.md").write_text(
+        "---\nname: good\nverify:\n  command: \"uv run --with pytest pytest test_ok.py -q\"\n---\n# good\n"
+    )
+    # bad: fails declared (real test file)
+    bad = skills / "bad"
+    bad.mkdir()
+    (bad / "test_bad.py").write_text("def test_bad(): assert False\n")
+    (bad / "SKILL.md").write_text(
+        "---\nname: bad\nverify:\n"
+        "  command: \"uv run --with pytest pytest test_bad.py -q\"\n"
+        "  expect_exit: 0\n---\n# bad\n"
+    )
+    # prose: no claim
+    prose = skills / "prose"
+    prose.mkdir()
+    (prose / "SKILL.md").write_text("---\nname: prose\n---\n# prose\n")
+    # archived: skipped
+    arch = skills / "archived-one"
+    arch.mkdir()
+    (arch / "SKILL.md").write_text("---\nname: archived-one\n---\n# arch\n")
+    usage = {
+        "good": {"state": "active"},
+        "bad": {"state": "active"},
+        "prose": {"state": "active"},
+        "archived-one": {"state": "archived"},
+    }
+    (skills / ".usage.json").write_text(json.dumps(usage))
+    return skills, tmp_path / "verdicts.json"
+
+
+def test_verify_all_writes_ledger_and_summary(tmp_path):
+    skills, verdicts = _make_skills_dir(tmp_path)
+    summary = falsify.verify_all(skills, verdicts, dry_run=False)
+    assert summary["pass"] == 1   # good
+    assert summary["fail"] == 1   # bad
+    assert summary["inconclusive"] == 1  # prose (archived skipped)
+    ledger = json.loads(verdicts.read_text())
+    assert ledger["bad"]["verdict"] == "fail"
+    assert ledger["bad"]["fail_count"] == 1
+    assert ledger["good"]["fail_count"] == 0
+    assert "archived-one" not in ledger
+
+
+def test_consequences_demotes_failures(tmp_path):
+    skills, verdicts = _make_skills_dir(tmp_path)
+    falsify.verify_all(skills, verdicts, dry_run=False)
+    usage = json.loads((skills / ".usage.json").read_text())
+    cons = falsify.apply_consequences(usage, json.loads(verdicts.read_text()), dry_run=False)
+    demoted = {d["skill"] for d in cons["demoted"]}
+    assert "bad" in demoted
+    assert usage["bad"]["state"] == "stale"
+    assert usage["good"]["state"] == "active"  # untouched
+
+
+def test_consequences_pinned_is_flagged_not_demoted(tmp_path):
+    skills, verdicts = _make_skills_dir(tmp_path)
+    falsify.verify_all(skills, verdicts, dry_run=False)
+    usage = json.loads((skills / ".usage.json").read_text())
+    usage["bad"]["pinned"] = True
+    cons = falsify.apply_consequences(usage, json.loads(verdicts.read_text()), dry_run=False)
+    flagged = {d["skill"] for d in cons["flagged"]}
+    assert "bad" in flagged
+    assert usage["bad"]["state"] == "active"  # NOT demoted (pinned)
+
+
+def test_dry_run_does_not_write(tmp_path):
+    skills, verdicts = _make_skills_dir(tmp_path)
+    falsify.verify_all(skills, verdicts, dry_run=True)
+    assert not verdicts.exists()
+
+
+def test_fail_count_accumulates_across_runs(tmp_path):
+    skills, verdicts = _make_skills_dir(tmp_path)
+    falsify.verify_all(skills, verdicts, dry_run=False)
+    falsify.verify_all(skills, verdicts, dry_run=False)
+    ledger = json.loads(verdicts.read_text())
+    assert ledger["bad"]["fail_count"] == 2
+    assert ledger["good"]["fail_count"] == 0

--- a/skills/autolearn-reviewer/scripts/test_inspector_server.py
+++ b/skills/autolearn-reviewer/scripts/test_inspector_server.py
@@ -68,3 +68,38 @@ def test_candidate_dismiss(tmp_path):
     assert status == 200 and body["ok"] is True
     rows = [json.loads(l) for l in (p / "candidates.jsonl").read_text(encoding="utf-8").splitlines() if l.strip()]
     assert rows[0]["status"] == "dismissed"
+
+
+def test_procedures_endpoint(tmp_path):
+    p = persona(tmp_path)
+    verdicts = {"my-skill": {"skill": "my-skill", "verdict": "fail", "method": "declared",
+                             "fail_count": 2, "evidence": "boom", "checked_at": "2026-07-16 10:00"}}
+    (p / "verdicts.json").write_text(json.dumps(verdicts), encoding="utf-8")
+    status, body = decode(call("GET", "/api/procedures", p))
+    assert status == 200 and body["my-skill"]["verdict"] == "fail"
+
+
+def test_shortcuts_endpoint(tmp_path):
+    p = persona(tmp_path)
+    cands = [{"kind": "help-chain", "golden_command": "foo run", "cost_tokens": 5000}]
+    (p / "shortcuts.json").write_text(json.dumps(cands), encoding="utf-8")
+    status, body = decode(call("GET", "/api/shortcuts", p))
+    assert status == 200 and len(body) == 1 and body[0]["golden_command"] == "foo run"
+
+
+def test_overview_failing_procedures_count(tmp_path):
+    p = persona(tmp_path)
+    verdicts = {
+        "a": {"verdict": "fail"}, "b": {"verdict": "pass"}, "c": {"verdict": "fail"},
+    }
+    (p / "verdicts.json").write_text(json.dumps(verdicts), encoding="utf-8")
+    status, body = decode(call("GET", "/api/overview", p))
+    assert status == 200 and body["failing_procedures"] == 2
+
+
+def test_procedures_endpoint_safe_when_absent(tmp_path):
+    p = persona(tmp_path)
+    status, body = decode(call("GET", "/api/procedures", p))
+    assert status == 200 and body == {}
+    status, body = decode(call("GET", "/api/shortcuts", p))
+    assert status == 200 and body == []

--- a/skills/autolearn-reviewer/scripts/test_outcomes.py
+++ b/skills/autolearn-reviewer/scripts/test_outcomes.py
@@ -1,0 +1,266 @@
+# /// script
+# dependencies = ["pytest"]
+# ///
+"""Tests for outcomes.py — the Certified Procedures shared spine.
+
+Builds a synthetic opencode.db with controlled `part` rows so indexing,
+ground-truth classification, skill-linkage, and the reuse-ledger derivation can
+be asserted without touching the real ~/.local/share/opencode/opencode.db.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import outcomes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a synthetic opencode.db matching the real `part` schema.
+# ---------------------------------------------------------------------------
+
+def _make_opencode_db(path: Path, parts: list[dict]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE `part` (
+            `id` text PRIMARY KEY,
+            `message_id` text NOT NULL,
+            `session_id` text NOT NULL,
+            `time_created` integer NOT NULL,
+            `time_updated` integer NOT NULL,
+            `data` text NOT NULL
+        );
+        """
+    )
+    for p in parts:
+        conn.execute(
+            "INSERT INTO part(id, message_id, session_id, time_created, time_updated, data) "
+            "VALUES (?,?,?,?,?,?)",
+            [p["id"], p["message_id"], p["session_id"], p["time_created"],
+             p["time_created"], json.dumps(p["data"])],
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def env(tmp_path) -> tuple[Path, Path]:
+    """Return (opencode_db, persona_dir)."""
+    ocdb = tmp_path / "opencode.db"
+    persona = tmp_path / "persona"
+    persona.mkdir()
+    return ocdb, persona
+
+
+def _tool_part(pid, sess, t, tool, status="completed", input_=None, output=""):
+    return {
+        "id": pid, "message_id": f"{pid}-msg", "session_id": sess, "time_created": t,
+        "data": {"type": "tool", "tool": tool,
+                 "state": {"status": status, "input": input_ or {}, "output": output}},
+    }
+
+
+def _step_part(pid, sess, t, *, input_t=0, output_t=0, reasoning=0, cost=0.0, reason="tool-calls"):
+    return {
+        "id": pid, "message_id": f"{pid}-msg", "session_id": sess, "time_created": t,
+        "data": {"type": "step-finish", "reason": reason, "cost": cost,
+                 "tokens": {"input": input_t, "output": output_t, "reasoning": reasoning,
+                            "cache": {"read": 0, "write": 0}}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Indexing
+# ---------------------------------------------------------------------------
+
+def test_index_increments_with_high_water_mark(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("p1", "s1", 1000, "bash", output="hi"),
+        _tool_part("p2", "s1", 2000, "bash", output="bye"),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    s1 = idx.index()
+    assert s1["tool_parts"] == 2
+    s2 = idx.index()  # nothing new
+    assert s2["tool_parts"] == 0
+    assert len(idx.list_tool_outcomes()) == 2
+    idx.close()
+
+
+def test_index_skips_non_tool_non_step_parts(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        {"id": "t1", "message_id": "m", "session_id": "s", "time_created": 1,
+         "data": {"type": "text", "text": "hello"}},
+        _tool_part("t2", "s", 2, "bash", output="x"),
+        {"id": "t3", "message_id": "m", "session_id": "s", "time_created": 3,
+         "data": {"type": "reasoning", "text": "..."}},
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    s = idx.index()
+    assert s["tool_parts"] == 1
+    assert s["skipped"] == 2
+    idx.close()
+
+
+def test_full_rebuild_clears(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [_tool_part("p1", "s1", 1000, "bash", output="x")])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    assert len(idx.list_tool_outcomes()) == 1
+    s = idx.index(full=True)
+    assert s["tool_parts"] == 1  # re-indexed after truncate
+    idx.close()
+
+
+# ---------------------------------------------------------------------------
+# Ground-truth classification (CP-OUT-003)
+# ---------------------------------------------------------------------------
+
+def test_classify_gt_test_command_is_strongest(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("t", "s", 1, "bash", output="pytest 2 passed",
+                   input_={"command": "uv run pytest"}),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    row = idx.list_tool_outcomes()[0]
+    assert row["gt_strength"] == 4
+
+
+def test_classify_gt_error_status_is_exit_code(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("t", "s", 1, "bash", status="error", output="boom"),
+        _tool_part("t2", "s", 2, "grep", output="matches"),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    rows = {r["part_id"]: r["gt_strength"] for r in idx.list_tool_outcomes()}
+    assert rows["t"] == 3   # error status -> exit-code strength
+    assert rows["t2"] == 1  # raw grep output
+
+
+def test_classify_gt_exit_code_parsed_from_output(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("t", "s", 1, "bash", status="completed",
+                   input_={"command": "make build"}, output="Exit code 2"),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    assert idx.list_tool_outcomes()[0]["gt_strength"] == 3
+    assert outcomes.exit_code_of("bash", "completed", {"command": "make build"}, "exit code 2") == 2
+
+
+def test_classify_gt_metadata_exit_is_ground_truth(env):
+    """Real opencode bash parts carry exit in state.metadata.exit (not output text)."""
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        {"id": "p1", "message_id": "m", "session_id": "s", "time_created": 1,
+         "data": {"type": "tool", "tool": "bash",
+                  "state": {"status": "completed", "input": {"command": "make build"},
+                            "output": "", "metadata": {"exit": 2}}}},
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    assert idx.list_tool_outcomes()[0]["gt_strength"] == 3
+    assert outcomes.exit_code_of("bash", "completed", {"command": "make build"}, "",
+                                 meta_exit=2) == 2
+
+
+def test_classify_gt_skill_load_is_zero(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("t", "s", 1, "skill", input_={"name": "marimo-pair"},
+                   output="## Skill ..."),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    row = idx.list_tool_outcomes()[0]
+    assert row["gt_strength"] == 0
+    assert row["skill_name"] == "marimo-pair"
+
+
+# ---------------------------------------------------------------------------
+# Skill linkage + reuse-ledger derivation (CP-OUT-005)
+# ---------------------------------------------------------------------------
+
+def test_skill_use_counts_derived_from_skill_loads(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("a", "s1", 1, "skill", input_={"name": "foo"}),
+        _tool_part("b", "s1", 2, "skill", input_={"name": "foo"}),
+        _tool_part("c", "s2", 3, "skill", input_={"name": "bar"}),
+        _tool_part("d", "s2", 4, "bash", output="x"),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    counts = idx.skill_use_counts()
+    assert counts == {"foo": 2, "bar": 1}
+
+
+def test_query_filters_by_min_gt_and_tool(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("a", "s", 1, "grep", output="m"),
+        _tool_part("b", "s", 2, "bash", status="error", output="x"),
+        _tool_part("c", "s", 3, "bash", output="pytest ok",
+                   input_={"command": "pytest"}),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    assert len(idx.list_tool_outcomes(min_gt=2)) == 2  # error + test
+    assert len(idx.list_tool_outcomes(tool="grep")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Step-cost indexing + session ordering
+# ---------------------------------------------------------------------------
+
+def test_step_cost_indexed_and_session_sequence_ordered(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("p1", "s", 100, "bash", output="x"),
+        _step_part("p2", "s", 200, input_t=10, output_t=5, cost=0.01),
+        _tool_part("p3", "s", 300, "bash", output="y"),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    s = idx.index()
+    assert s["step_parts"] == 1
+    seq = idx.session_sequences("s")
+    assert [r["part_id"] for r in seq] == ["p1", "p3"]  # tool rows only, ordered
+    idx.close()
+
+
+def test_status_reports_histogram_and_counts(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("a", "s", 1, "grep", output="m"),
+        _tool_part("b", "s", 2, "bash", status="error", output="x"),
+        _tool_part("c", "s", 3, "skill", input_={"name": "z"}),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    st = idx.status()
+    assert st["tool_parts"] == 3
+    assert st["skill_loads"] == 1
+    assert st["gt_histogram"].get("1") == 1  # grep
+    assert st["gt_histogram"].get("3") == 1  # error
+
+
+def test_missing_opencode_db_returns_no_db_marker(env):
+    ocdb, persona = env
+    # never create ocdb
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    s = idx.index()
+    assert s.get("no_opencode_db") is True
+    assert s["tool_parts"] == 0
+    idx.close()

--- a/skills/autolearn-reviewer/scripts/test_shortcuts.py
+++ b/skills/autolearn-reviewer/scripts/test_shortcuts.py
@@ -1,0 +1,192 @@
+# /// script
+# dependencies = ["pytest"]
+# ///
+"""Tests for shortcuts.py — Loop 2 (roundabout detection + golden-path gating)."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import outcomes
+import shortcuts
+
+
+# ---------------------------------------------------------------------------
+# Build a synthetic outcomes.db with controlled ordered tool_outcome + step_cost
+# ---------------------------------------------------------------------------
+
+def _idx(tmp_path) -> outcomes.OutcomeIndex:
+    persona = tmp_path / "persona"
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, tmp_path / "opencode.db")
+    idx.init_schema()
+    return idx
+
+
+def _tool(idx, sess, seq, tool, status, command=None, skill=None):
+    inp = {}
+    if command is not None:
+        inp["command"] = command
+    if skill is not None:
+        inp["name"] = skill
+    idx.conn.execute(
+        "INSERT INTO tool_outcome(part_id, session_id, message_id, seq, time_created, "
+        "tool, status, skill_name, input_json, output_peek, gt_strength) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        [f"p{seq}", sess, f"p{seq}-m", seq, seq, tool, status, skill,
+         json.dumps(inp), "", 1],
+    )
+
+
+def _step(idx, sess, seq, tokens):
+    idx.conn.execute(
+        "INSERT INTO step_cost(part_id, session_id, seq, time_created, reason, "
+        "tokens_in, tokens_out, tokens_reasoning, cache_read, cache_write, cost) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        [f"s{seq}", sess, seq, seq, "tool-calls", tokens, 0, 0, 0, 0, 0.0],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Roundabout detection (CP-SHO-001)
+# ---------------------------------------------------------------------------
+
+def test_help_chain_detected_with_golden_command(tmp_path):
+    idx = _idx(tmp_path)
+    # 3 help probes then the working command
+    for i, cmd in enumerate(["foo --help", "foo bar --help", "foo bar baz --help"], start=10):
+        _tool(idx, "sess", i, "bash", "completed", command=cmd)
+    _tool(idx, "sess", 14, "bash", "completed", command="foo bar baz --flag value")
+    idx.conn.commit()
+    cands = shortcuts.detect_roundabouts(idx, config={"roundabout_help_depth": 2,
+                                                       "roundabout_recent_sessions": 5})
+    chains = [c for c in cands if c["kind"] == "help-chain"]
+    assert len(chains) == 1
+    assert chains[0]["golden_command"] == "foo bar baz --flag value"
+    assert chains[0]["run_length"] == 3
+    idx.close()
+
+
+def test_help_chain_below_depth_not_detected(tmp_path):
+    idx = _idx(tmp_path)
+    _tool(idx, "sess", 1, "bash", "completed", command="foo --help")
+    _tool(idx, "sess", 2, "bash", "completed", command="foo bar")
+    idx.conn.commit()
+    cands = shortcuts.detect_roundabouts(idx, config={"roundabout_help_depth": 2,
+                                                       "roundabout_recent_sessions": 5})
+    assert not [c for c in cands if c["kind"] == "help-chain"]
+    idx.close()
+
+
+def test_error_run_detected_with_golden_command(tmp_path):
+    idx = _idx(tmp_path)
+    # 3 errors then a completed call with the same tool
+    for i in (1, 2, 3):
+        _tool(idx, "sess", i, "bash", "error", command=f"make build{i}")
+    _tool(idx, "sess", 4, "bash", "completed", command="make build")
+    idx.conn.commit()
+    cands = shortcuts.detect_roundabouts(idx, config={"roundabout_error_run": 3,
+                                                       "roundabout_help_depth": 99,
+                                                       "roundabout_recent_sessions": 5})
+    runs = [c for c in cands if c["kind"] == "error-run"]
+    assert len(runs) == 1
+    assert runs[0]["golden_command"] == "make build"
+    assert runs[0]["run_length"] == 3
+    idx.close()
+
+
+def test_error_run_with_different_tool_successor_records_null_golden(tmp_path):
+    idx = _idx(tmp_path)
+    _tool(idx, "sess", 1, "bash", "error")
+    _tool(idx, "sess", 2, "bash", "error")
+    _tool(idx, "sess", 3, "bash", "error")
+    _tool(idx, "sess", 4, "grep", "completed", command="grep x")  # different tool
+    idx.conn.commit()
+    cands = shortcuts.detect_roundabouts(idx, config={"roundabout_error_run": 3,
+                                                       "roundabout_help_depth": 99,
+                                                       "roundabout_recent_sessions": 5})
+    runs = [c for c in cands if c["kind"] == "error-run"]
+    assert len(runs) == 1                     # recorded (CP-SHO-002) ...
+    assert runs[0]["golden_command"] is None  # ... but not promotable (different tool)
+    idx.close()
+
+
+def test_help_chain_unrelated_golden_is_null(tmp_path):
+    idx = _idx(tmp_path)
+    _tool(idx, "sess", 1, "bash", "completed", command="foo --help")
+    _tool(idx, "sess", 2, "bash", "completed", command="foo --help")
+    _tool(idx, "sess", 3, "bash", "completed", command="bar run")  # unrelated first word
+    idx.conn.commit()
+    cands = shortcuts.detect_roundabouts(idx, config={"roundabout_help_depth": 2,
+                                                       "roundabout_recent_sessions": 5})
+    chains = [c for c in cands if c["kind"] == "help-chain"]
+    assert len(chains) == 1
+    assert chains[0]["golden_command"] is None  # relevance check (M6) rejects it
+    idx.close()
+
+
+def test_help_chain_no_terminal_success_is_null(tmp_path):
+    idx = _idx(tmp_path)
+    _tool(idx, "sess", 1, "bash", "completed", command="foo --help")
+    _tool(idx, "sess", 2, "bash", "completed", command="foo --help")
+    idx.conn.commit()  # run off the end — no successor
+    cands = shortcuts.detect_roundabouts(idx, config={"roundabout_help_depth": 2,
+                                                       "roundabout_recent_sessions": 5})
+    chains = [c for c in cands if c["kind"] == "help-chain"]
+    assert len(chains) == 1                     # recorded as pure-cost finding (CP-SHO-002)
+    assert chains[0]["golden_command"] is None
+    idx.close()
+
+
+# ---------------------------------------------------------------------------
+# Token cost + ordering (CP-SHO-001)
+# ---------------------------------------------------------------------------
+
+def test_cost_is_summed_and_candidates_sorted_desc(tmp_path):
+    idx = _idx(tmp_path)
+    _tool(idx, "sess", 10, "bash", "completed", command="x --help")
+    _tool(idx, "sess", 11, "bash", "completed", command="x y --help")
+    _tool(idx, "sess", 12, "bash", "completed", command="x y z run")
+    _step(idx, "sess", 10, 1000)
+    _step(idx, "sess", 11, 1500)
+    _step(idx, "sess", 12, 500)
+    idx.conn.commit()
+    cands = shortcuts.detect_roundabouts(idx, config={"roundabout_help_depth": 2,
+                                                       "roundabout_recent_sessions": 5})
+    assert cands[0]["cost_tokens"] == 3000  # 1000+1500+500
+    idx.close()
+
+
+# ---------------------------------------------------------------------------
+# Promotion gating + min-savings (CP-SHO-003, CP-SHO-004)
+# ---------------------------------------------------------------------------
+
+def test_promotable_filters_by_min_tokens_and_requires_golden():
+    cands = [
+        {"kind": "help-chain", "cost_tokens": 5000, "golden_command": "foo run"},
+        {"kind": "help-chain", "cost_tokens": 500, "golden_command": "foo run"},
+        {"kind": "error-run", "cost_tokens": 9000, "golden_command": None},
+    ]
+    prom = shortcuts.promotable(cands, config={"shortcut_promote_min_tokens": 2000})
+    assert len(prom) == 1
+    assert prom[0]["golden_command"] == "foo run"
+
+
+def test_verify_candidate_safe_pass(tmp_path):
+    (tmp_path / "test_ok.py").write_text("def test_ok(): assert True\n")
+    c = {"golden_command": "uv run --with pytest pytest test_ok.py -q"}
+    res = shortcuts.verify_candidate(c, config={"shortcut_verify_timeout_s": 120}, cwd=tmp_path)
+    assert res["verdict"] == "pass"
+
+
+def test_verify_candidate_unsafe_is_inconclusive():
+    c = {"golden_command": "rm -rf /"}
+    res = shortcuts.verify_candidate(c, config={"shortcut_verify_timeout_s": 10})
+    assert res["verdict"] == "inconclusive"
+
+
+def test_verify_candidate_no_command_is_inconclusive():
+    res = shortcuts.verify_candidate({"golden_command": None})
+    assert res["verdict"] == "inconclusive"


### PR DESCRIPTION
## What this does (plain English)

Gives autolearn the ability to **falsify its own procedures** (skills) and to **shortcut roundabout workflows to a golden path** — the discipline of the [Schema ARC-AGI-3 harness](https://schema-harness.github.io/) (maintain a backtested, executable model of the world; let reality falsify it), adapted to the non-deterministic world of a software repo.

It indexes the tool-call/step-cost data in `opencode.db` that the existing FTS5 search index deliberately throws away, and runs two co-equal loops on it:

- **Loop 1 — Falsify (correctness):** verify a skill's procedure still produces its claimed outcome; auto-demote skills that fail.
- **Loop 2 — Efficiency (golden path):** detect expensive roundabout tool sequences in past sessions, extract the direct invocation, and stage it for promotion — **gated by Loop 1 verification** so lucky one-off commands don't harden into bad shortcuts.

> Stacked on #5 (this branch is based on `feat/capture-failure-paths`). The diff below is exactly the 6 Certified Procedures commits; the base auto-retargets to `main` once #5 merges.

## Why skills + outcomes, not memories + text

An earlier "Certified Memory" concept (backtest prose memories against prose snippets) was rejected on review: prose-vs-prose retains none of Schema's verifiability, the FTS5 index excludes tool outcomes by design, and lexical contradiction is polarity-blind and drift-confounding. The sound target is **skills** (autolearn's program-analog) falsified against **ground-truth-bearing tool outcomes** (`state.metadata.exit`, test results, user corrections). See HLD Decisions 10–12.

## Architecture

```
opencode.db.part  ── tool parts · step-finish parts · skill-load parts
        │
        ▼
outcomes.py  ── SHARED SPINE (incremental, ground-truth-weighted)
        │              side effect: derives per-skill use_count → revives .usage.json
        ├─────────────────────────┐
        ▼                         ▼
falsify.py (Loop 1)          shortcuts.py (Loop 2)
 verify skills               detect roundabouts, extract golden path,
 deterministic fail → demote  promote gated by falsify
```

## How it was verified

- **76 tests green** (`outcomes`/`falsify`/`shortcuts` + inspector); 2 read-only review subagents run, all real findings fixed:
  - data-loss blocker (`outcomes init --full` wiping the index when `opencode.db` was missing),
  - exit codes were misread from output text instead of `state.metadata.exit` → fixing this took **ground-truth coverage 4k → 38k**,
  - non-unique `(time_created)` high-water mark (parts share ms) → now composite `(time,id)`,
  - bypassable declared-command safe-subset (`uv run python -c "shutil.rmtree(...)"` now refused),
  - help-chain "golden" grabbing unrelated calls; null-golden roundabouts per spec.
- **End-to-end against the real `opencode.db`**: indexed 107,667 tool parts + 99,406 step-cost rows, **38,782 ground-truth outcomes**, reuse ledger derived for 57 skills (the `.usage.json` `use_count` field was always 0 — it now self-repairs).

## Commit breakdown

1. `docs(reviewer)` — reconcile improve.py Step 4 contradiction
2. `docs(certified-procedures)` — LLD + EARS + HLD Decisions 10–12; mark Memory Insight shipped
3. `feat` — `outcomes.py` spine
4. `feat` — `falsify.py` (Loop 1)
5. `feat` — `shortcuts.py` (Loop 2)
6. `feat` — wire CLI + curator integration + inspector endpoints

## Honest caveats / deferred

- **Falsify batch scope** is the persona's autolearn-created skills (mostly prose). Extending it to all discoverable skills under `~/.agents/skills/` (where the scripted, falsifiable skills live) needs an allowlist — so `falsify run` reports mostly `0/0/0` today; **Loop 2 (`shortcuts detect`) works now**.
- Correlation-based (probabilistic) falsification is deferred and, when added, is suggestion-only — never auto-demote.
- `outcomes.db` is persona-local and deliberately **not** synced (opencode.db is machine-local; verdict provenance is machine-local).

## Try it

\`\`\`bash
autolearn outcomes status     # index health + ground-truth histogram
autolearn falsify run         # verify skills against claims
autolearn falsify verdicts    # per-skill verdict ledger
autolearn shortcuts detect    # find roundabout workflows + golden paths
autolearn shortcuts list      # staged candidates
\`\`\`