### PR TITLE
feat(certified-procedures): falsify installed skills + self-verify

### DIFF
--- a/docs/designs/certified-procedures/LLD.md
+++ b/docs/designs/certified-procedures/LLD.md
@@ -237,16 +237,22 @@ def cmd_falsify_verdicts(args)   # print the ledger
 ```
 
 **Deterministic-first scope:** only `test-suite` and `declared` claims are
-evaluated (the user's chosen first path). Skills with no claim get
-`verdict: inconclusive, method: none` and are left untouched. Correlation-based
-falsification (skill-load → subsequent ground-truth outcomes) is **deferred** —
-it is suggestion-only and must never auto-demote.
+evaluated (the user's chosen first path), with **declared > test-suite**
+ranking — a declared `verify:` block is the author's exact command (deps,
+ignores) and is trusted over the bare `pytest scripts/` heuristic, which may
+return `inconclusive` when a skill's tests need deps the bare command can't
+resolve. Skills with no claim get `verdict: inconclusive, method: none` and are
+left untouched. Correlation-based falsification (skill-load → subsequent
+ground-truth outcomes) is **deferred** — it is suggestion-only and must never
+auto-demote.
 
-**Batch scope:** `verify_all` scans the persona's `skills/` dir
-(autolearn-created skills — matching the curator's lifecycle scope). Verifying
-*all* discoverable skills under `~/.agents/skills/` (where most scripted,
-falsifiable skills live) is a follow-up gated behind an allowlist, since batch
-re-execution of every installed skill's tests is expensive and noisy. The
+**Batch scope:** by default `verify_all` scans the persona's `skills/` dir
+(autolearn-created skills — cheap, used by the curator). `falsify run --all`
+and `falsify run --id NAME` additionally scan `~/.agents/skills/` (where
+installed skills with test suites / `verify:` blocks live), so the harness can
+falsify skills like `autolearn-reviewer` itself. Skills not tracked in
+`.usage.json` (i.e. not autolearn-created) are **verified and flagged on
+failure but never auto-demoted** — autolearn does not manage their lifecycle. The
 outcome index, reuse-ledger derivation, and roundabout detection already cover
 all data regardless of where a skill lives.
 
@@ -335,8 +341,9 @@ Three top-level nouns, parallel to `retention` / `topics`:
 
 ## Edge Cases
 
-1. **A skill with both a test suite and a `verify:` block** — the test suite
-   wins (strongest claim); the declared block is noted but not run.
+1. **A skill with both a test suite and a `verify:` block** — the declared
+   block wins (the author's exact command, with deps/ignores, is trusted over
+   the bare test-suite heuristic); the test suite is noted but not run.
 2. **Non-deterministic tests** — a single fail is enough to demote (fail_count
    reaches threshold on first failure). Pinned skills (`pinned: true` in
    `.usage.json`) are exempt from auto-demote (flagged only), matching the

--- a/skills/autolearn-reviewer/SKILL.md
+++ b/skills/autolearn-reviewer/SKILL.md
@@ -7,6 +7,9 @@ description: |
   review cycles. Do NOT load this skill during normal conversation;
   it is for the autolearn-reviewer agent only.
 license: MIT
+verify:
+  command: "uv run --with pytest --with python-slugify pytest scripts/ --ignore=scripts/test_sync_e2e.py --ignore=scripts/test_sync_crypto.py"
+  expect_exit: 0
 ---
 
 # Autolearn Reviewer

--- a/skills/autolearn-reviewer/scripts/autolearn.py
+++ b/skills/autolearn-reviewer/scripts/autolearn.py
@@ -1924,7 +1924,8 @@ def main():
     fal = sub.add_parser("falsify", help="Falsify skills against their claims (Loop 1)", parents=[persona_parent])
     fal_sub = fal.add_subparsers(dest="subcommand")
     fal_run = fal_sub.add_parser("run", help="Verify skills and apply consequences")
-    fal_run.add_argument("--id", default=None, help="Verify a single skill by name")
+    fal_run.add_argument("--id", default=None, help="Verify a single skill by name (searches persona + ~/.agents/skills)")
+    fal_run.add_argument("--all", action="store_true", help="Also scan ~/.agents/skills/ (installed skills with claims)")
     fal_run.add_argument("--dry-run", action="store_true", help="Report without mutating")
     fal_sub.add_parser("verdicts", help="Print the per-skill verdict ledger")
 

--- a/skills/autolearn-reviewer/scripts/falsify.py
+++ b/skills/autolearn-reviewer/scripts/falsify.py
@@ -98,17 +98,23 @@ def _read_frontmatter_verify(skill_md: Path) -> dict | None:
 
 # @spec CP-FAL-001
 def claims_of(skill_dir: Path) -> list[dict]:
-    """Falsifiable claims, strongest first: test-suite > declared."""
+    """Falsifiable claims, strongest first: declared > test-suite > none.
+
+    A declared ``verify:`` block wins because the author specified the exact
+    command (deps, ignores, etc.); the bare test-suite command is a best-effort
+    fallback for skills that ship tests but no declared block, and may come back
+    inconclusive when those tests need deps the bare command can't resolve.
+    """
     claims: list[dict] = []
+    declared = _read_frontmatter_verify(skill_dir / "SKILL.md")
+    if declared:
+        claims.append({"method": "declared", **declared})
     scripts_dir = skill_dir / "scripts"
     if scripts_dir.is_dir():
         tests = sorted(scripts_dir.glob("test_*.py"))
         if tests:
             claims.append({"method": "test-suite",
                            "tests": [str(p.relative_to(skill_dir)) for p in tests]})
-    declared = _read_frontmatter_verify(skill_dir / "SKILL.md")
-    if declared:
-        claims.append({"method": "declared", **declared})
     return claims
 
 
@@ -226,15 +232,38 @@ def _save_usage(skills_dir: Path, usage: dict) -> None:
 # @spec CP-FAL-002
 def verify_all(skills_dir: Path, verdicts_path: Path, *,
                config: dict | None = None, dry_run: bool = False,
-               only: str | None = None) -> dict:
-    """Verify every active skill; write the verdict ledger; return a summary."""
+               only: str | None = None, extra_dirs: list[Path] | None = None) -> dict:
+    """Verify every active skill; write the verdict ledger; return a summary.
+
+    By default scans ``skills_dir`` (the persona's autolearn-created skills).
+    ``extra_dirs`` extends the scan (e.g. ``~/.agents/skills/``) so installed
+    skills with falsifiable claims can be verified too. Skills are deduped by
+    name (first occurrence wins). Installed skills not tracked in ``.usage.json``
+    are verified and flagged on failure but never auto-demoted (autolearn only
+    manages the lifecycle of skills it created).
+    """
     cfg = {**DEFAULT_CONFIG, **(config or {})}
     usage = _load_usage(skills_dir)
     ledger = _load_verdicts(verdicts_path)
     summary = {"pass": 0, "fail": 0, "inconclusive": 0, "demoted": 0}
 
-    skill_dirs = [d for d in sorted(skills_dir.iterdir())
-                  if d.is_dir() and (d / "SKILL.md").exists()]
+    seen: dict[str, Path] = {}  # name -> chosen dir
+    for d in [skills_dir, *(extra_dirs or [])]:
+        if not d.is_dir():
+            continue
+        for sd in sorted(d.iterdir()):
+            if not (sd.is_dir() and (sd / "SKILL.md").exists()):
+                continue
+            name = sd.name
+            if name not in seen:
+                seen[name] = sd
+            elif not claims_of(seen[name]) and claims_of(sd):
+                # prefer a duplicate that actually has a falsifiable claim
+                # (e.g. an installed skill with a test suite / verify: block
+                # over a persona-local prose stub of the same name)
+                seen[name] = sd
+    skill_dirs = list(seen.values())
+
     for sd in skill_dirs:
         name = sd.name
         if only and name != only:
@@ -265,8 +294,11 @@ def apply_consequences(usage: dict, ledger: dict, *, config: dict | None = None,
                        dry_run: bool = False) -> dict:
     """Demote skills whose deterministic fail_count reached the threshold.
 
-    Pinned skills are flagged only (never demoted). Probabilistic verdicts are
-    never produced by this module, so nothing here acts on weak evidence.
+    Only skills already tracked in ``usage`` (autolearn-created) may be demoted.
+    Pinned skills are flagged only (never demoted). Skills not in ``usage``
+    (e.g. installed skills surfaced via ``--all``) are flagged only — autolearn
+    does not manage their lifecycle. Probabilistic verdicts are never produced
+    by this module, so nothing here acts on weak evidence.
     """
     cfg = {**DEFAULT_CONFIG, **(config or {})}
     threshold = int(cfg["falsify_fail_demote_after"])
@@ -276,10 +308,14 @@ def apply_consequences(usage: dict, ledger: dict, *, config: dict | None = None,
             continue
         if int(v.get("fail_count", 0)) < threshold:
             continue
-        meta = usage.setdefault(name, {})
-        pinned = bool(meta.get("pinned"))
         flag = {"skill": name, "fail_count": v["fail_count"],
                 "evidence": v.get("evidence", "")[:200]}
+        if name not in usage:
+            # not managed by autolearn — report only, never demote/pollute usage
+            out["flagged"].append(flag)
+            continue
+        meta = usage[name]
+        pinned = bool(meta.get("pinned"))
         if pinned:
             out["flagged"].append(flag)
             continue
@@ -308,19 +344,26 @@ def cmd_falsify_run(args):
     verdicts_path = persona_dir / VERDICTS_FILE
     only = getattr(args, "id", None)
     dry = bool(getattr(args, "dry_run", False))
-    summary = verify_all(skills_dir, verdicts_path, only=only, dry_run=dry)
+    scan_all = bool(getattr(args, "all", False))
+    # When verifying a specific skill by name or scanning everything, also look
+    # under the installed-skills dir (~/.agents/skills) — that's where skills
+    # with test suites / declared verify: blocks actually live.
+    agents_dir = Path(os.environ.get("AGENTS_SKILLS_DIR", Path.home() / ".agents" / "skills"))
+    extra = [agents_dir] if (scan_all or only) else []
+    summary = verify_all(skills_dir, verdicts_path, only=only, dry_run=dry, extra_dirs=extra)
     usage = _load_usage(skills_dir)
     cons = apply_consequences(usage, summary["ledger"], dry_run=dry)
     if not dry:
         _save_usage(skills_dir, usage)
-    print(f"Falsified skills: {summary['pass']} pass, {summary['fail']} fail, "
+    scope = "all (persona + installed)" if extra else "persona-only"
+    print(f"Falsified skills [{scope}]: {summary['pass']} pass, {summary['fail']} fail, "
           f"{summary['inconclusive']} inconclusive.")
     if cons["demoted"]:
         print(f"Demoted to stale ({'would' if dry else 'did'}):")
         for d in cons["demoted"]:
             print(f"  {d['skill']} (fails={d['fail_count']})")
     if cons["flagged"]:
-        print("Flagged (pinned / already stale):")
+        print("Flagged (installed / pinned / already stale):")
         for d in cons["flagged"]:
             print(f"  {d['skill']} (fails={d['fail_count']})")
 

--- a/skills/autolearn-reviewer/scripts/test_falsify.py
+++ b/skills/autolearn-reviewer/scripts/test_falsify.py
@@ -50,15 +50,17 @@ def test_claims_none_when_nothing_falsifiable(tmp_path):
     assert falsify.claims_of(skill) == []
 
 
-def test_test_suite_ranked_above_declared(tmp_path):
+def test_declared_ranked_above_test_suite(tmp_path):
+    """A declared verify: block wins over the bare test-suite heuristic: the
+    author's exact command (deps + ignores) is more trustworthy than `pytest scripts/`."""
     skill = tmp_path / "both"
     (skill / "scripts").mkdir(parents=True)
     (skill / "scripts" / "test_a.py").write_text("def test_a(): assert 1")
     (skill / "SKILL.md").write_text(
-        "---\nname: both\nverify:\n  command: \"pytest -q\"\n---\n# Both\n"
+        "---\nname: both\nverify:\n  command: \"uv run --with pytest pytest scripts/test_a.py -q\"\n---\n# Both\n"
     )
     claims = falsify.claims_of(skill)
-    assert claims[0]["method"] == "test-suite"
+    assert claims[0]["method"] == "declared"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the \"documented next step\" from #7: \`falsify run\` reported \`0/0/0\` because its batch scope was persona-only, while the skills with falsifiable claims live under \`~/.agents/skills/\`.

## What changed

- **Scope expansion:** \`falsify run --all\` and \`falsify run --id NAME\` now also scan \`~/.agents/skills/\`. Default (no flag) and the curator stay persona-scope (cheap).
- **Dedup prefers claims:** when the same skill name exists in both dirs, the copy with a falsifiable claim wins (e.g. installed \`autolearn-reviewer\` with a test suite beats a persona-local prose stub).
- **Declared > test-suite:** a declared \`verify:\` block now ranks above the bare \`pytest scripts/\` heuristic — the author's exact command (deps + ignores) is trusted over the dumb fallback, which returns \`inconclusive\` when tests need deps it can't resolve.
- **No pollution:** installed skills are verified + flagged on failure but never auto-demoted (autolearn doesn't manage their lifecycle).
- **Self-verify:** added a \`verify:\` block to \`autolearn-reviewer/SKILL.md\` — the canonical example, and the harness now falsifies itself.

## Verified

- 76 tests green.
- \`falsify run --id autolearn-reviewer\` → **1 pass** (runs the 76-test suite via the declared block).
- \`falsify run --all\` → 1 pass / 73 inconclusive (the rest are prose skills with no claim — honest).

## Honest remaining gap

The 73 inconclusives are skills with no \`verify:\` block and no test suite — they're not falsifiable *yet*. Broad coverage needs either (a) more skills to declare \`verify:\` blocks (the reviewer could propose them), or (b) the deferred correlation-based (probabilistic, suggestion-only) layer. This PR makes the deterministic path actually bite for the skills that do have claims.