### PR TITLE
feat(skill-mgmt): track usage for user-installed skills

### DIFF
--- a/docs/designs/skill-management/LLD.md
+++ b/docs/designs/skill-management/LLD.md
@@ -194,7 +194,7 @@ Curator is idempotent — running it multiple times produces the same result.
 
 **Phase 1 — Update existing entries.** For every skill already in `.usage.json`, copy the latest `use_count` from the outcome index and refresh `last_activity_at` if the outcome index observes a more recent load than the recorded date. Never modifies `created_by` on existing entries (SM-LC-016).
 
-**Phase 2 — Add `tracked-manual` entries for previously-untracked skills.** Scan all configured skill-discovery directories (`~/.agents/skills/`, `~/.config/opencode/skills/`, configurable via `AGENTS_SKILLS_DIR`-style env vars in future) for `SKILL.md` files. For any skill on disk that:
+**Phase 2 — Add `tracked-manual` entries for previously-untracked skills.** Scan all configured skill-discovery directories (`~/.agents/skills/`, `~/.config/opencode/skills/`, configurable via the `AUTOLEARN_SKILL_DISCOVERY` env var) for `SKILL.md` files. For any skill on disk that:
 
 - is **not** already in `.usage.json`, AND
 - has been **loaded at least once** (count > 0 in the outcome index)
@@ -207,18 +207,90 @@ The disk scan **must skip** any directory whose name starts with `.archive` (e.g
 
 ### Why this is non-destructive
 
-`tracked-manual` entries are **observe-only**. The curator's retention loop checks `meta.get("created_by") != "autolearn"` (autolearn.py:753) and skips; the new `"tracked-manual"` value therefore falls through the same exemption the legacy `"user"` value already used. A `tracked-manual` skill is never auto-archived, never state-transitioned, and never deleted. The data exists purely so audits (manual or future tooling) can answer "is this skill actually being used?" with real signal rather than mtime heuristics.
+`tracked-manual` entries are **observe-only**. The curator's retention loop checks `meta.get("created_by") != "autolearn"` (autolearn.py:870) and skips; the new `"tracked-manual"` value therefore falls through the same exemption the legacy `"user"` value already used. A `tracked-manual` skill is never auto-archived, never state-transitioned, and never deleted. The data exists purely so audits (manual or future tooling) can answer "is this skill actually being used?" with real signal rather than mtime heuristics.
 
 ### Discovery
 
+The scan is performed by the `_skill_discovery_dirs()` helper, which returns a list of directories to walk. By default it returns:
+
 ```python
-SKILL_DISCOVERY_DIRS = [
+[
     Path.home() / ".agents" / "skills",
     Path.home() / ".config" / "opencode" / "skills",
 ]
 ```
 
-Mirrors the directories opencode scans for skill discovery. Project-local `.agents/skills/` directories are intentionally **not** scanned — they are repo-specific and would produce noise in the global `.usage.json`. (Future work: optional project-aware scan.)
+For test isolation, the `AUTOLEARN_SKILL_DISCOVERY` env var (os-path-separated list) overrides the defaults. Mirrors the directories opencode scans for skill discovery. Project-local `.agents/skills/` directories are intentionally **not** scanned — they are repo-specific and would produce noise in the global `.usage.json`. (Future work: optional project-aware scan.)
+
+> **Known asymmetry (not a bug):** `opencode.db` records every `tool='skill'` load regardless of where the skill lives on disk. Skills loaded only from project-local directories (e.g. `~/Documents/brain42/.agents/skills/conflict-detector`) appear in `signals` but cannot be matched by the disk scan, so they never become `tracked-manual` entries. They inflate the summary's `skills_with_loads` count without contributing to `added`. This is accepted because project-local skills are inherently repo-scoped, while `.usage.json` is global. A future project-aware scan could close the gap.
+
+## Design Rationale: Why Two Stores (`.usage.json` + `outcomes.db`)
+
+A reader will notice the system maintains **two** data stores that both carry skill-usage signal: `.usage.json` (a JSON file) and `outcomes.db` (a SQLite database, populated by the Certified Procedures subsystem). This section documents why both exist and the trade-off we knowingly accept.
+
+### Data flow
+
+```
+1. opencode itself records every tool call (including `skill`) into its own
+   SQLite ledger:
+       ~/.local/share/opencode/opencode.db  →  `part` table
+   This is opencode's core behavior. No autolearn plugin hooks the skill-load
+   lifecycle; the source of truth is opencode.db itself.
+
+2. autolearn's OutcomeIndex.index() pulls incrementally from opencode.db
+   using a high-water mark (runs as a side-effect of `curator run` and on
+   explicit `outcomes init`):
+       opencode.db.part  →  outcomes.db.tool_outcome
+   This is a polling read, not a push.
+
+3. repair_skill_use_counts() copies the derived signal back out:
+       outcomes.db  →  .usage.json
+   Specifically the `use_count` and `last_activity_at` fields. This is the
+   "repair" step that keeps the two stores in sync.
+```
+
+### What each store holds
+
+| Field | `.usage.json` | `outcomes.db` | Notes |
+|-------|---------------|---------------|-------|
+| `use_count` | ✅ derived (drifts) | ✅ authoritative | `COUNT(*) GROUP BY skill_name` on `tool='skill'` rows |
+| `last_activity_at` | ✅ derived (drifts) | ✅ authoritative | `MAX(time_created)` per skill |
+| `created_by` | ✅ | ❌ | Provenance: `autolearn`, `tracked-manual`, `user` |
+| `created_at` | ✅ | ❌ | Skill creation/installation date |
+| `patch_count` | ✅ | ❌ | Could be in outcomes.db if we recorded patch events |
+| `state` (active/stale/archived) | ✅ | ❌ | Curator lifecycle state |
+| `pinned` | ✅ | ❌ | User-set exemption flag |
+| `archived_at` | ✅ | ❌ | When the curator archived the skill |
+
+### Why we keep both (and accept the repair mechanism as a smell)
+
+The two fields `.usage.json` derives from `outcomes.db` (`use_count`, `last_activity_at`) **are a code smell** — having two sources of truth for the same data is what makes the `repair_*()` function necessary. The legitimate fields `.usage.json` holds that have no natural home in outcomes.db are lifecycle state (`state`, `pinned`, `archived_at`), provenance (`created_by`, `created_at`), and patch telemetry (`patch_count`).
+
+The known cleaner factoring would be one of:
+
+- **A. Consolidate entirely** — add a `skill_meta` table to `outcomes.db`, delete `.usage.json`. Pro: single store, no drift. Con: every `load_usage`/`save_usage` callsite (~15) needs rewriting; migration path for existing JSON files.
+- **B. Strip `.usage.json` to state-only** — remove `use_count`/`last_activity_at` from `.usage.json`; callers JOIN with outcomes.db for usage. Pro: smallest change that removes the drift surface. Con: ~5 callers need a JOIN.
+
+**We deliberately accept the smell for now** because:
+
+1. **`.usage.json` predates `outcomes.db`.** The skill-management subsystem shipped first; the Certified Procedures subsystem (with `outcomes.db`) was added later. The repair mechanism was the minimal-disruption way to wire usage signal into the existing file.
+2. **Neither store syncs across machines.** We confirmed `SYNC_FILES` (autolearn.py:1391) excludes both `.usage.json` and `outcomes.db` — both are machine-local. The "sync purposes" justification one might assume for `.usage.json` does not apply. The right eventual home for cross-machine usage telemetry is an open design question.
+3. **The blast radius of consolidation is uncalled for today.** The repair mechanism costs one function and one curator side-effect. Consolidation would touch ~15 callsites and require migration logic. Until that cost is justified by a concrete pain point (e.g. observed drift bugs, a perf issue, a feature blocked by the split), the asymmetry stands.
+
+### Mitigation we DO apply
+
+- The repair function runs on **every** `curator run`, so drift is bounded to the curator interval (currently daily at 3am).
+- The disk scan + outcome index are idempotent; running them multiple times produces the same result.
+- `repair_skill_use_counts()` never modifies `created_by` on existing entries (SM-LC-016), so a stuck repair can't silently reclassify skills.
+- The `tracked-manual` value introduced here is observe-only (SM-LC-017): the retention loop's existing `created_by != "autolearn"` filter (autolearn.py:870) skips them, so even if repair misbehaves, no `tracked-manual` skill gets auto-archived.
+
+### When to revisit
+
+Reopen this design decision when any of these becomes true:
+
+- Drift between `.usage.json` and `outcomes.db` is observed in practice (repair isn't keeping up).
+- A feature needs `use_count` to be transactionally consistent with skill creation (currently it isn't — the file write and the outcome index are independent).
+- Cross-machine sync wants to ship usage telemetry (would force a decision on which store is canonical).
 
 ## Edge Cases
 

--- a/docs/designs/skill-management/LLD.md
+++ b/docs/designs/skill-management/LLD.md
@@ -80,19 +80,36 @@ The `created_by: autolearn` frontmatter tag distinguishes agent-created skills f
     "last_activity_at": "2026-06-05",
     "state": "active",
     "pinned": false
+  },
+  "atomic-commits": {
+    "created_by": "tracked-manual",
+    "created_at": "2026-07-19",
+    "use_count": 5,
+    "patch_count": 0,
+    "last_activity_at": "2026-07-19",
+    "state": "active",
+    "pinned": false
   }
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| created_by | string | "autolearn" or "user" |
+| created_by | string | "autolearn", "tracked-manual", or "user" (legacy; rarely written) |
 | created_at | string | ISO date |
-| use_count | number | Times skill was loaded (currently always 0 — tracking not yet wired) |
-| patch_count | number | Times skill was patched |
-| last_activity_at | string | ISO date of last create/patch/usage |
+| use_count | number | Times skill was loaded. Authoritatively derived from the outcome index by `repair_skill_use_counts()`. |
+| patch_count | number | Times skill was patched (autolearn-created only) |
+| last_activity_at | string | ISO date of last create/patch/usage. For `tracked-manual` entries, derived from the most recent `tool='skill'` part in `opencode.db`. |
 | state | string | "active", "stale", or "archived" |
 | pinned | boolean | If true, exempt from curator transitions |
+
+#### `created_by` values and what they mean
+
+| Value | Meaning | Curator manages it? |
+|-------|---------|---------------------|
+| `"autolearn"` | Skill was created by the autolearn-reviewer agent via `skill create`. | Yes — subject to stale/archive transitions (SM-LC-007). |
+| `"tracked-manual"` | Skill was installed by the user (or a tooling installer) and lives on disk outside `.autolearn/`. Tracked for usage telemetry only, added by `repair_skill_use_counts()` when the outcome index observes at least one load. | **No** — never auto-archived, never state-transitioned. Surfaced in audits so the user can decide. |
+| `"user"` | Legacy value from earlier schema drafts. Treated the same as `"tracked-manual"` for retention purposes (not managed). | No |
 
 ### Curator State (`.curator_state.json`)
 
@@ -164,10 +181,44 @@ Configurable thresholds from `config.yaml`:
 
 Exemptions:
 - `pinned: true` skills are never transitioned
-- `created_by != "autolearn"` skills are never transitioned
+- `created_by != "autolearn"` skills are never transitioned (this explicitly includes `"tracked-manual"` entries — SM-LC-017)
 - Already-archived skills are skipped
 
 Curator is idempotent — running it multiple times produces the same result.
+
+## Usage Tracking Repair
+
+`repair_skill_use_counts()` runs as a side-effect of every `curator run` (orchestrated under CP-INT-001). Its job is to keep `.usage.json`'s `use_count` and `last_activity_at` fields in sync with the authoritative source: the `tool='skill'` parts recorded in `opencode.db` and indexed by the outcome index (CP-OUT-005).
+
+### Two phases
+
+**Phase 1 — Update existing entries.** For every skill already in `.usage.json`, copy the latest `use_count` from the outcome index and refresh `last_activity_at` if the outcome index observes a more recent load than the recorded date. Never modifies `created_by` on existing entries (SM-LC-016).
+
+**Phase 2 — Add `tracked-manual` entries for previously-untracked skills.** Scan all configured skill-discovery directories (`~/.agents/skills/`, `~/.config/opencode/skills/`, configurable via `AGENTS_SKILLS_DIR`-style env vars in future) for `SKILL.md` files. For any skill on disk that:
+
+- is **not** already in `.usage.json`, AND
+- has been **loaded at least once** (count > 0 in the outcome index)
+
+add a new entry with `created_by: "tracked-manual"`, `state: "active"`, `created_at` derived from the `SKILL.md` file mtime, `use_count` from the index, and `last_activity_at` derived from the most recent `tool='skill'` part timestamp.
+
+### Non-resurrection rule (SM-LC-015)
+
+The disk scan **must skip** any directory whose name starts with `.archive` (e.g. `.archive/`, `.archive-manual/`). This guarantees that a user who has explicitly archived a manual skill (e.g. via `mv ~/.agents/skills/foo ~/.agents/skills/.archive-manual/`) will not have it silently re-appear in `.usage.json` on the next curator run.
+
+### Why this is non-destructive
+
+`tracked-manual` entries are **observe-only**. The curator's retention loop checks `meta.get("created_by") != "autolearn"` (autolearn.py:753) and skips; the new `"tracked-manual"` value therefore falls through the same exemption the legacy `"user"` value already used. A `tracked-manual` skill is never auto-archived, never state-transitioned, and never deleted. The data exists purely so audits (manual or future tooling) can answer "is this skill actually being used?" with real signal rather than mtime heuristics.
+
+### Discovery
+
+```python
+SKILL_DISCOVERY_DIRS = [
+    Path.home() / ".agents" / "skills",
+    Path.home() / ".config" / "opencode" / "skills",
+]
+```
+
+Mirrors the directories opencode scans for skill discovery. Project-local `.agents/skills/` directories are intentionally **not** scanned — they are repo-specific and would produce noise in the global `.usage.json`. (Future work: optional project-aware scan.)
 
 ## Edge Cases
 

--- a/docs/designs/skill-management/skill-lifecycle-EARS.md
+++ b/docs/designs/skill-management/skill-lifecycle-EARS.md
@@ -29,6 +29,16 @@
 - [x] **SM-LC-011**: If no transitions are needed, the system shall print "Curator run complete: no transitions needed."
 - [x] **SM-LC-012**: If transitions occur, the system shall print each transition type with the affected skill names.
 
+## Usage Tracking Repair
+
+The `repair_skill_use_counts()` side-effect of `curator run` keeps `.usage.json`'s `use_count` and `last_activity_at` fields in sync with the authoritative outcome index (CP-OUT-005). These requirements govern the extension that brings previously-untracked, user-installed skills under telemetry coverage without subjecting them to lifecycle management.
+
+- [ ] **SM-LC-013**: When `curator run` invokes `repair_skill_use_counts()`, the system SHALL scan all configured skill-discovery directories for `SKILL.md` files whose skill name is not present in `.usage.json`.
+- [ ] **SM-LC-014**: For each on-disk skill not in `.usage.json` that has been loaded at least once (count > 0 in the outcome index), the system SHALL add a tracking entry with `created_by: "tracked-manual"`, `state: "active"`, `created_at` derived from the `SKILL.md` file mtime, `use_count` copied from the index, and `last_activity_at` derived from the most recent `tool='skill'` part timestamp.
+- [ ] **SM-LC-015**: The disk scan SHALL skip any directory whose name starts with `.archive` (matches `.archive/`, `.archive-manual/`, etc.), so previously-archived manual skills are not resurrected into `.usage.json`.
+- [ ] **SM-LC-016**: When updating an existing `.usage.json` entry, the system SHALL NOT modify the `created_by` field. Only `use_count` and `last_activity_at` are refreshed.
+- [ ] **SM-LC-017**: The retention/lifecycle transition loop SHALL continue to skip any entry whose `created_by` is not `"autolearn"`, including the new `"tracked-manual"` entries introduced by SM-LC-014. `tracked-manual` skills are observe-only: tracked for usage, never auto-archived.
+
 ## Related Documents
 
 - [Skill Management LLD](./LLD.md)

--- a/docs/designs/skill-management/skill-lifecycle-EARS.md
+++ b/docs/designs/skill-management/skill-lifecycle-EARS.md
@@ -33,11 +33,11 @@
 
 The `repair_skill_use_counts()` side-effect of `curator run` keeps `.usage.json`'s `use_count` and `last_activity_at` fields in sync with the authoritative outcome index (CP-OUT-005). These requirements govern the extension that brings previously-untracked, user-installed skills under telemetry coverage without subjecting them to lifecycle management.
 
-- [ ] **SM-LC-013**: When `curator run` invokes `repair_skill_use_counts()`, the system SHALL scan all configured skill-discovery directories for `SKILL.md` files whose skill name is not present in `.usage.json`.
-- [ ] **SM-LC-014**: For each on-disk skill not in `.usage.json` that has been loaded at least once (count > 0 in the outcome index), the system SHALL add a tracking entry with `created_by: "tracked-manual"`, `state: "active"`, `created_at` derived from the `SKILL.md` file mtime, `use_count` copied from the index, and `last_activity_at` derived from the most recent `tool='skill'` part timestamp.
-- [ ] **SM-LC-015**: The disk scan SHALL skip any directory whose name starts with `.archive` (matches `.archive/`, `.archive-manual/`, etc.), so previously-archived manual skills are not resurrected into `.usage.json`.
-- [ ] **SM-LC-016**: When updating an existing `.usage.json` entry, the system SHALL NOT modify the `created_by` field. Only `use_count` and `last_activity_at` are refreshed.
-- [ ] **SM-LC-017**: The retention/lifecycle transition loop SHALL continue to skip any entry whose `created_by` is not `"autolearn"`, including the new `"tracked-manual"` entries introduced by SM-LC-014. `tracked-manual` skills are observe-only: tracked for usage, never auto-archived.
+- [x] **SM-LC-013**: When `curator run` invokes `repair_skill_use_counts()`, the system SHALL scan all configured skill-discovery directories for `SKILL.md` files whose skill name is not present in `.usage.json`.
+- [x] **SM-LC-014**: For each on-disk skill not in `.usage.json` that has been loaded at least once (count > 0 in the outcome index), the system SHALL add a tracking entry with `created_by: "tracked-manual"`, `state: "active"`, `created_at` derived from the `SKILL.md` file mtime, `use_count` copied from the index, and `last_activity_at` derived from the most recent `tool='skill'` part timestamp.
+- [x] **SM-LC-015**: The disk scan SHALL skip any directory whose name starts with `.archive` (matches `.archive/`, `.archive-manual/`, etc.), so previously-archived manual skills are not resurrected into `.usage.json`.
+- [x] **SM-LC-016**: When updating an existing `.usage.json` entry, the system SHALL NOT modify the `created_by` field. Only `use_count` and `last_activity_at` are refreshed.
+- [x] **SM-LC-017**: The retention/lifecycle transition loop SHALL continue to skip any entry whose `created_by` is not `"autolearn"`, including the new `"tracked-manual"` entries introduced by SM-LC-014. `tracked-manual` skills are observe-only: tracked for usage, never auto-archived.
 
 ## Related Documents
 

--- a/skills/autolearn-reviewer/scripts/autolearn.py
+++ b/skills/autolearn-reviewer/scripts/autolearn.py
@@ -848,7 +848,7 @@ def cmd_skill_usage(args):
 
 
 # @spec SM-LC-001, SM-LC-002, SM-LC-003, SM-LC-004
-# @spec SM-LC-005, SM-LC-006, SM-LC-007
+# @spec SM-LC-005, SM-LC-006, SM-LC-007, SM-LC-017
 # @spec SM-LC-008, SM-LC-009, SM-LC-011, SM-LC-012
 def cmd_curator_run(args):
     config = load_config()
@@ -966,8 +966,12 @@ def cmd_curator_run(args):
     if isinstance(cp_indexed, dict) and cp_indexed.get("gt_ge2") is not None:
         print(f"  outcomes: indexed {cp_indexed.get('tool_parts', 0)} tool parts "
               f"({cp_indexed.get('gt_ge2', 0)} ground-truth)")
-    if isinstance(cp.get("usage_repaired"), dict) and cp["usage_repaired"].get("updated"):
-        print(f"  reuse ledger: repaired {cp['usage_repaired']['updated']} skill use_counts")
+    if isinstance(cp.get("usage_repaired"), dict):
+        ur = cp["usage_repaired"]
+        if ur.get("updated"):
+            print(f"  usage tracking: repaired use_count on {ur['updated']} skill(s)")
+        if ur.get("added"):
+            print(f"  usage tracking: newly tracking {ur['added']} manual skill(s)")
 
 
 # @spec SM-LC-010

--- a/skills/autolearn-reviewer/scripts/autolearn.py
+++ b/skills/autolearn-reviewer/scripts/autolearn.py
@@ -248,26 +248,143 @@ def save_usage(data: dict):
     USAGE_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
 
 
-# @spec CP-OUT-005, CP-INT-001
+# @spec CP-OUT-005, CP-INT-001, SM-LC-013, SM-LC-014, SM-LC-015, SM-LC-016
 def repair_skill_use_counts() -> dict:
-    """Write skill load counts (derived from the outcome index) into .usage.json.
+    """Write skill load signals (derived from the outcome index) into .usage.json.
 
-    The ``use_count`` field is plumbed but never incremented today (skill-mgmt
-    LLD:91). The outcome index derives it from ``tool='skill'`` part counts,
-    which is authoritative for "times loaded in a recorded session".
+    Two phases:
+
+    1. **Update existing entries.** For every skill already in ``.usage.json``,
+       copy the latest ``use_count`` from the outcome index and refresh
+       ``last_activity_at`` if the index observes a more recent load than the
+       recorded date. ``created_by`` is never modified (SM-LC-016).
+
+    2. **Add ``tracked-manual`` entries for previously-untracked skills.**
+       Scan configured skill-discovery dirs for ``SKILL.md`` files. For any
+       on-disk skill that is (a) not already in ``.usage.json``, (b) not in an
+       ``.archive*`` directory (SM-LC-015), and (c) has been loaded at least
+       once (count > 0 in the outcome index), add a tracking entry with
+       ``created_by: "tracked-manual"`` (SM-LC-014).
+
+    Returns a summary dict ``{"updated": N, "added": M, "skills_with_loads": K}``.
     """
     usage = load_usage()
     idx = outcomes.OutcomeIndex(OUTCOMES_DB, OPENCODE_DB)
-    counts = idx.skill_use_counts()
+    signals = idx.skill_use_signals()
     idx.close()
+
+    # Phase 1 — refresh use_count + last_activity_at on existing entries.
     updated = 0
     for name, meta in usage.items():
-        if name in counts and meta.get("use_count") != counts[name]:
-            meta["use_count"] = counts[name]
+        sig = signals.get(name)
+        if sig is None:
+            continue
+        dirty = False
+        new_count = sig["count"]
+        if meta.get("use_count") != new_count:
+            meta["use_count"] = new_count
+            dirty = True
+        # Refresh last_activity_at if the index sees a more recent load.
+        last_ms = sig["last_seen_ms"]
+        if last_ms:
+            last_iso = datetime.fromtimestamp(last_ms / 1000).strftime("%Y-%m-%d")
+            if meta.get("last_activity_at", "") < last_iso:
+                meta["last_activity_at"] = last_iso
+                dirty = True
+        if dirty:
             updated += 1
-    if updated:
+
+    # Phase 2 — add tracked-manual entries for on-disk skills (SM-LC-013/014/015).
+    added = 0
+    on_disk = _scan_skill_dirs_for_repair()
+    for name, created_at_iso in on_disk.items():
+        if name in usage:
+            continue  # SM-LC-016: never touch existing entries
+        sig = signals.get(name)
+        if sig is None or sig["count"] == 0:
+            continue  # never loaded, no signal worth tracking
+        last_ms = sig["last_seen_ms"]
+        last_iso = (
+            datetime.fromtimestamp(last_ms / 1000).strftime("%Y-%m-%d")
+            if last_ms else created_at_iso
+        )
+        usage[name] = {
+            "created_by": "tracked-manual",
+            "created_at": created_at_iso,
+            "use_count": sig["count"],
+            "patch_count": 0,
+            "last_activity_at": last_iso,
+            "state": "active",
+            "pinned": False,
+        }
+        added += 1
+
+    if updated or added:
         save_usage(usage)
-    return {"updated": updated, "skills_with_loads": len(counts)}
+    return {
+        "updated": updated,
+        "added": added,
+        "skills_with_loads": len(signals),
+    }
+
+
+# Skill discovery roots — mirrors opencode's own skill-discovery scan so that
+# `repair_skill_use_counts()` phase 2 sees the same skills the agent sees.
+# Override via the ``AUTOLEARN_SKILL_DISCOVERY`` env var (``:``-separated) for
+# test isolation.
+# @spec SM-LC-013
+def _skill_discovery_dirs() -> list:
+    env = os.environ.get("AUTOLEARN_SKILL_DISCOVERY")
+    if env:
+        return [Path(p) for p in env.split(os.pathsep) if p]
+    return [
+        Path.home() / ".agents" / "skills",
+        Path.home() / ".config" / "opencode" / "skills",
+    ]
+
+
+# @spec SM-LC-013, SM-LC-015
+def _scan_skill_dirs_for_repair() -> dict:
+    """Return ``{skill_name: created_at_iso}`` for skills on disk, excluding archives.
+
+    Iterates every configured skill-discovery directory. For each subdirectory
+    containing a ``SKILL.md``:
+
+    - skips any directory whose name starts with ``.archive`` (SM-LC-015) —
+      this covers ``.archive/`` (autolearn-managed) and ``.archive-manual/``
+      (ad-hoc user archival) alike, so neither is resurrected into
+      ``.usage.json``;
+    - records ``created_at`` as the ``SKILL.md`` file mtime (best available
+      proxy for "when this skill was installed");
+    - first-seen-wins precedence across discovery dirs (a skill shadowed by an
+      earlier dir is not overwritten).
+    """
+    found: dict[str, str] = {}
+    for d in _skill_discovery_dirs():
+        if not d.is_dir():
+            continue
+        try:
+            entries = sorted(d.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if not entry.is_dir():
+                continue
+            # SM-LC-015: skip any archive variant.
+            if entry.name.startswith(".archive"):
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            if entry.name in found:
+                continue  # first-seen-wins
+            try:
+                mtime = skill_md.stat().st_mtime
+                mtime_iso = datetime.fromtimestamp(mtime).strftime("%Y-%m-%d")
+            except OSError:
+                mtime_iso = date.today().isoformat()
+            found[entry.name] = mtime_iso
+    return found
 
 
 def load_config() -> dict:

--- a/skills/autolearn-reviewer/scripts/outcomes.py
+++ b/skills/autolearn-reviewer/scripts/outcomes.py
@@ -386,6 +386,33 @@ class OutcomeIndex:
         ).fetchall()
         return {r["skill_name"]: int(r["c"]) for r in rows}
 
+    # @spec CP-OUT-005, SM-LC-013, SM-LC-014
+    def skill_use_signals(self) -> dict[str, dict]:
+        """``{skill_name: {"count": int, "last_seen_ms": int}}`` derived from ``tool='skill'`` parts.
+
+        Extends :meth:`skill_use_counts` with the most recent load timestamp per
+        skill (``MAX(time_created)``). The timestamp feeds ``last_activity_at``
+        when ``repair_skill_use_counts()`` adds ``tracked-manual`` entries for
+        previously-untracked on-disk skills (SM-LC-014).
+
+        ``last_seen_ms`` is ``0`` when the outcome table has no rows for the
+        skill (defensive — should not happen since the row only exists when
+        there is at least one load).
+        """
+        rows = self.conn.execute(
+            "SELECT skill_name, COUNT(*) AS c, MAX(time_created) AS last_ms "
+            "FROM tool_outcome "
+            "WHERE tool='skill' AND skill_name IS NOT NULL "
+            "GROUP BY skill_name"
+        ).fetchall()
+        return {
+            r["skill_name"]: {
+                "count": int(r["c"]),
+                "last_seen_ms": int(r["last_ms"]) if r["last_ms"] is not None else 0,
+            }
+            for r in rows
+        }
+
     def status(self) -> dict:
         def count(sql: str) -> int:
             return int(self.conn.execute(sql).fetchone()[0])

--- a/skills/autolearn-reviewer/scripts/test_outcomes.py
+++ b/skills/autolearn-reviewer/scripts/test_outcomes.py
@@ -207,6 +207,43 @@ def test_skill_use_counts_derived_from_skill_loads(env):
     assert counts == {"foo": 2, "bar": 1}
 
 
+# @spec SM-LC-013, SM-LC-014
+def test_skill_use_signals_returns_count_and_last_seen(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("a", "s1", 1_000, "skill", input_={"name": "foo"}),
+        _tool_part("b", "s1", 5_000, "skill", input_={"name": "foo"}),
+        _tool_part("c", "s2", 9_000, "skill", input_={"name": "bar"}),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    signals = idx.skill_use_signals()
+    assert signals["foo"] == {"count": 2, "last_seen_ms": 5_000}
+    assert signals["bar"] == {"count": 1, "last_seen_ms": 9_000}
+
+
+def test_skill_use_signals_empty_when_no_skill_loads(env):
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("a", "s", 1, "bash", output="x"),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    assert idx.skill_use_signals() == {}
+
+
+def test_skill_use_signals_excludes_null_skill_name(env):
+    """A skill tool call with malformed input (no name) must not pollute signals."""
+    ocdb, persona = env
+    _make_opencode_db(ocdb, [
+        _tool_part("a", "s", 1, "skill", input_={}, output=""),  # no name
+        _tool_part("b", "s", 2, "skill", input_={"name": "foo"}),
+    ])
+    idx = outcomes.OutcomeIndex(persona / outcomes.OUTCOMES_DB_NAME, ocdb)
+    idx.index()
+    assert idx.skill_use_signals() == {"foo": {"count": 1, "last_seen_ms": 2}}
+
+
 def test_query_filters_by_min_gt_and_tool(env):
     ocdb, persona = env
     _make_opencode_db(ocdb, [

--- a/skills/autolearn-reviewer/scripts/test_repair_skill_use_counts.py
+++ b/skills/autolearn-reviewer/scripts/test_repair_skill_use_counts.py
@@ -79,10 +79,13 @@ def _make_skill_on_disk(base: Path, name: str, contents: str = "# skill\n") -> P
 def isolated_env(tmp_path, monkeypatch):
     """Isolate persona dir, opencode.db path, and skill discovery dirs.
 
-    Returns a namespace with the relevant paths so individual tests can build
-    up the exact on-disk state they need.
+    Patches ALL the module-level paths in autolearn.py that the repair code
+    touches, including DATA_HOME / PERSONAS_DIR / REGISTRY_FILE, so the test
+    can never pollute the real ~/.autolearn/ even on a fresh CI runner where
+    ensure_dirs() would otherwise mkdir the real directory.
     """
-    persona = tmp_path / "persona"
+    home = tmp_path / "autolearn_home"
+    persona = home / "personas" / "default"
     skills_dir = persona / "skills"
     skills_dir.mkdir(parents=True)
 
@@ -93,12 +96,21 @@ def isolated_env(tmp_path, monkeypatch):
 
     opencode_db = tmp_path / "opencode.db"
 
-    # Override module-level paths in autolearn.py.
+    # Patch every related module-level path. set_persona() does this in
+    # production; we replicate the relevant subset here.
+    monkeypatch.setattr(autolearn, "DATA_HOME", home)
+    monkeypatch.setattr(autolearn, "PERSONAS_DIR", home / "personas")
+    monkeypatch.setattr(autolearn, "REGISTRY_FILE", home / ".persona_registry.json")
     monkeypatch.setattr(autolearn, "ACTIVE_PERSONA_DIR", persona)
     monkeypatch.setattr(autolearn, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(autolearn, "ARCHIVE_DIR", skills_dir / ".archive")
     monkeypatch.setattr(autolearn, "USAGE_FILE", skills_dir / ".usage.json")
+    monkeypatch.setattr(autolearn, "CURATOR_STATE_FILE", persona / ".curator_state.json")
     monkeypatch.setattr(autolearn, "OUTCOMES_DB", persona / "outcomes.db")
     monkeypatch.setattr(autolearn, "OPENCODE_DB", opencode_db)
+    # Pre-create the registry file so init_registry() is a no-op even if a
+    # future code path calls ensure_dirs() before repair.
+    (home / ".persona_registry.json").write_text('{"default": "default"}')
 
     # Discovery dirs via env var so _skill_discovery_dirs() picks them up.
     monkeypatch.setenv(
@@ -107,6 +119,7 @@ def isolated_env(tmp_path, monkeypatch):
     )
 
     return type("NS", (), {
+        "home": home,
         "persona": persona,
         "skills_dir": skills_dir,
         "usage_file": skills_dir / ".usage.json",
@@ -344,3 +357,103 @@ def test_scan_first_seen_wins_across_dirs(isolated_env):
     found = autolearn._scan_skill_dirs_for_repair()
     assert len(found) == 1
     assert "dup" in found
+
+
+# Real ~/.agents/skills/ is a mix of real directories and symlinks to
+# ~/.autolearn/personas/default/skills/. Path.is_dir() follows symlinks
+# (correct for the scan), and Phase 2's `if name in usage: continue` correctly
+# skips autolearn-created skills symlinked into the discovery dir. This test
+# pins that behavior so a future refactor can't silently break it.
+def test_scan_handles_symlinked_skill_dirs(isolated_env, tmp_path):
+    ns = isolated_env
+    # A real skill lives outside the discovery dir; a symlink points to it.
+    real_skill_dir = tmp_path / "outside_skill_dir"
+    real_skill_dir.mkdir()
+    (real_skill_dir / "SKILL.md").write_text("# symlinked\n")
+
+    symlink_path = ns.agents_skills / "symlinked-skill"
+    symlink_path.symlink_to(real_skill_dir, target_is_directory=True)
+
+    found = autolearn._scan_skill_dirs_for_repair()
+    assert "symlinked-skill" in found
+
+
+# ---------------------------------------------------------------------------
+# SM-LC-017 — tracked-manual entries survive curator run (observe-only)
+# ---------------------------------------------------------------------------
+
+# @spec SM-LC-017
+def test_tracked_manual_entry_not_transitioned_by_curator_run(isolated_env, monkeypatch):
+    """A tracked-manual entry passes through curator run unchanged.
+
+    SM-LC-017 guarantees that the retention/lifecycle transition loop skips
+    any entry whose created_by is not 'autolearn'. This test crafts a
+    tracked-manual entry old enough to trip BOTH the stale (30d) and archive
+    (90d) thresholds, runs cmd_curator_run, and asserts the entry is neither
+    state-transitioned nor moved to .archive/.
+    """
+    ns = isolated_env
+    # Build a minimal config so load_config() returns the defaults we expect.
+    (ns.persona / "config.yaml").write_text(
+        "review_threshold: 10\nsession_review_on_idle: true\nmax_conversation_buffer: 50\n"
+        "curator_interval_days: 7\nstale_after_days: 30\narchive_after_days: 90\n"
+        "escalation_threshold: 3\n"
+    )
+
+    # Ancient last_activity so both thresholds are tripped.
+    ancient = "2020-01-01"
+    ns.usage_file.write_text(json.dumps({
+        "old-manual": {
+            "created_by": "tracked-manual",
+            "created_at": ancient,
+            "use_count": 5,
+            "patch_count": 0,
+            "last_activity_at": ancient,
+            "state": "active",
+            "pinned": False,
+        }
+    }))
+
+    # Build a fake argparse Namespace so cmd_curator_run gets what it expects.
+    args = type("Args", (), {"persona": "default"})()
+
+    # Run the curator. We don't care about the summary output, only that the
+    # entry is preserved unchanged.
+    autolearn.cmd_curator_run(args)
+
+    usage = json.loads(ns.usage_file.read_text())
+    assert "old-manual" in usage, "tracked-manual skill was dropped"
+    entry = usage["old-manual"]
+    assert entry["state"] == "active", f"state was transitioned: {entry['state']}"
+    assert entry["created_by"] == "tracked-manual"
+    # And the skill dir was NOT moved to .archive/ (we never created one on
+    # disk; if the curator had tried to archive it, the rename would have
+    # failed loudly).
+    assert not (ns.skills_dir / ".archive" / "old-manual").exists()
+
+
+# @spec SM-LC-017 — regression test for the comparison operator.
+def test_curator_run_skips_legacy_user_entries_too(isolated_env):
+    """The pre-existing 'user' value also benefits from the same exemption."""
+    ns = isolated_env
+    (ns.persona / "config.yaml").write_text(
+        "stale_after_days: 30\narchive_after_days: 90\nescalation_threshold: 3\n"
+    )
+    ns.usage_file.write_text(json.dumps({
+        "legacy-skill": {
+            "created_by": "user",  # legacy value
+            "created_at": "2020-01-01",
+            "use_count": 0,
+            "patch_count": 0,
+            "last_activity_at": "2020-01-01",
+            "state": "active",
+            "pinned": False,
+        }
+    }))
+
+    args = type("Args", (), {"persona": "default"})()
+    autolearn.cmd_curator_run(args)
+
+    usage = json.loads(ns.usage_file.read_text())
+    assert usage["legacy-skill"]["state"] == "active"
+    assert usage["legacy-skill"]["created_by"] == "user"

--- a/skills/autolearn-reviewer/scripts/test_repair_skill_use_counts.py
+++ b/skills/autolearn-reviewer/scripts/test_repair_skill_use_counts.py
@@ -1,0 +1,346 @@
+# /// script
+# dependencies = [
+#     "pytest",
+#     "pyyaml",
+#     "python-slugify",
+#     "cryptography",
+#     "keyring",
+#     "keyrings.alt",
+#     "requests",
+# ]
+# ///
+"""Tests for repair_skill_use_counts() and the _scan_skill_dirs_for_repair() helper.
+
+Covers SM-LC-013 through SM-LC-017 (usage tracking repair extension that brings
+previously-untracked, user-installed skills under telemetry coverage without
+subjecting them to lifecycle management).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make autolearn.py + outcomes.py importable when run via uv run / pytest.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import autolearn
+import outcomes
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic opencode.db + isolated skill discovery dirs
+# ---------------------------------------------------------------------------
+
+def _make_opencode_db(path: Path, skill_loads: list[tuple[str, int]]) -> None:
+    """Build a minimal opencode.db with `skill_loads` = [(name, time_created_ms), ...]."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE `part` (
+            `id` text PRIMARY KEY,
+            `message_id` text NOT NULL,
+            `session_id` text NOT NULL,
+            `time_created` integer NOT NULL,
+            `time_updated` integer NOT NULL,
+            `data` text NOT NULL
+        );
+        """
+    )
+    for i, (skill_name, t) in enumerate(skill_loads):
+        conn.execute(
+            "INSERT INTO part(id, message_id, session_id, time_created, time_updated, data) "
+            "VALUES (?,?,?,?,?,?)",
+            [
+                f"p{i}", f"m{i}", "s", t, t,
+                json.dumps({
+                    "type": "tool", "tool": "skill",
+                    "state": {"status": "completed", "input": {"name": skill_name}, "output": ""},
+                }),
+            ],
+        )
+    conn.commit()
+    conn.close()
+
+
+def _make_skill_on_disk(base: Path, name: str, contents: str = "# skill\n") -> Path:
+    """Create a synthetic SKILL.md at base/name/SKILL.md and return its path."""
+    skill_dir = base / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(contents)
+    return skill_md
+
+
+@pytest.fixture
+def isolated_env(tmp_path, monkeypatch):
+    """Isolate persona dir, opencode.db path, and skill discovery dirs.
+
+    Returns a namespace with the relevant paths so individual tests can build
+    up the exact on-disk state they need.
+    """
+    persona = tmp_path / "persona"
+    skills_dir = persona / "skills"
+    skills_dir.mkdir(parents=True)
+
+    agents_skills = tmp_path / "agents_skills"
+    agents_skills.mkdir()
+    config_skills = tmp_path / "config_skills"
+    config_skills.mkdir()
+
+    opencode_db = tmp_path / "opencode.db"
+
+    # Override module-level paths in autolearn.py.
+    monkeypatch.setattr(autolearn, "ACTIVE_PERSONA_DIR", persona)
+    monkeypatch.setattr(autolearn, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(autolearn, "USAGE_FILE", skills_dir / ".usage.json")
+    monkeypatch.setattr(autolearn, "OUTCOMES_DB", persona / "outcomes.db")
+    monkeypatch.setattr(autolearn, "OPENCODE_DB", opencode_db)
+
+    # Discovery dirs via env var so _skill_discovery_dirs() picks them up.
+    monkeypatch.setenv(
+        "AUTOLEARN_SKILL_DISCOVERY",
+        f"{agents_skills}{os.pathsep}{config_skills}",
+    )
+
+    return type("NS", (), {
+        "persona": persona,
+        "skills_dir": skills_dir,
+        "usage_file": skills_dir / ".usage.json",
+        "agents_skills": agents_skills,
+        "config_skills": config_skills,
+        "opencode_db": opencode_db,
+    })()
+
+
+def _index_outcomes(ns) -> None:
+    """Build the outcome index from the synthetic opencode.db."""
+    idx = outcomes.OutcomeIndex(ns.persona / "outcomes.db", ns.opencode_db)
+    idx.index()
+    idx.close()
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — update existing entries
+# ---------------------------------------------------------------------------
+
+# @spec SM-LC-016
+def test_repair_updates_use_count_on_existing_entry(isolated_env):
+    ns = isolated_env
+    _make_opencode_db(ns.opencode_db, [("atomic-commits", 1_000), ("atomic-commits", 2_000)])
+    _index_outcomes(ns)
+
+    ns.usage_file.write_text(json.dumps({
+        "atomic-commits": {
+            "created_by": "autolearn",
+            "created_at": "2026-01-01",
+            "use_count": 0,
+            "patch_count": 0,
+            "last_activity_at": "2026-01-01",
+            "state": "active",
+            "pinned": False,
+        }
+    }))
+
+    summary = autolearn.repair_skill_use_counts()
+    assert summary["updated"] == 1
+    assert summary["added"] == 0
+
+    usage = json.loads(ns.usage_file.read_text())
+    assert usage["atomic-commits"]["use_count"] == 2
+    # SM-LC-016: created_by unchanged.
+    assert usage["atomic-commits"]["created_by"] == "autolearn"
+
+
+def test_repair_refreshes_last_activity_at_when_newer_load_observed(isolated_env):
+    ns = isolated_env
+    # Use a timestamp well after the existing last_activity_at; compute the
+    # expected local-date via the same datetime.fromtimestamp() the
+    # implementation uses, so the test is TZ-agnostic.
+    load_ms = 1_782_748_801_000
+    expected_iso = __import__("datetime").datetime.fromtimestamp(load_ms / 1000).strftime("%Y-%m-%d")
+    _make_opencode_db(ns.opencode_db, [("foo", load_ms)])
+    _index_outcomes(ns)
+
+    ns.usage_file.write_text(json.dumps({
+        "foo": {
+            "created_by": "autolearn", "created_at": "2026-01-01",
+            "use_count": 0, "patch_count": 0,
+            "last_activity_at": "2026-01-01",
+            "state": "active", "pinned": False,
+        }
+    }))
+
+    summary = autolearn.repair_skill_use_counts()
+    assert summary["updated"] == 1
+
+    usage = json.loads(ns.usage_file.read_text())
+    assert usage["foo"]["last_activity_at"] == expected_iso
+
+
+def test_repair_leaves_unchanged_entries_unwritten(isolated_env):
+    ns = isolated_env
+    _make_opencode_db(ns.opencode_db, [("foo", 1_000)])
+    _index_outcomes(ns)
+
+    initial = {
+        "foo": {
+            "created_by": "autolearn", "created_at": "2026-01-01",
+            "use_count": 1, "patch_count": 0,
+            "last_activity_at": "2026-01-01",  # 1_000ms == 1970-01-01, older not newer
+            "state": "active", "pinned": False,
+        }
+    }
+    ns.usage_file.write_text(json.dumps(initial))
+
+    summary = autolearn.repair_skill_use_counts()
+    # use_count already correct (1), last_activity_at already newer than the load (1_000ms = 1970-01-01).
+    assert summary["updated"] == 0
+    assert summary["added"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — add tracked-manual entries (SM-LC-013, SM-LC-014, SM-LC-015)
+# ---------------------------------------------------------------------------
+
+# @spec SM-LC-013, SM-LC-014
+def test_repair_adds_tracked_manual_entry_for_loaded_untracked_skill(isolated_env):
+    ns = isolated_env
+    _make_opencode_db(ns.opencode_db, [("atomic-commits", 1_000), ("atomic-commits", 2_000)])
+    _index_outcomes(ns)
+
+    # Skill exists on disk but not in .usage.json.
+    _make_skill_on_disk(ns.agents_skills, "atomic-commits")
+
+    ns.usage_file.write_text(json.dumps({}))
+
+    summary = autolearn.repair_skill_use_counts()
+    assert summary["added"] == 1
+    assert summary["updated"] == 0
+
+    usage = json.loads(ns.usage_file.read_text())
+    entry = usage["atomic-commits"]
+    assert entry["created_by"] == "tracked-manual"
+    assert entry["use_count"] == 2
+    assert entry["state"] == "active"
+    assert entry["pinned"] is False
+    assert entry["patch_count"] == 0
+    # last_activity_at derived from the most recent load (2_000ms in local time).
+    expected_last = __import__("datetime").datetime.fromtimestamp(2.0).strftime("%Y-%m-%d")
+    assert entry["last_activity_at"] == expected_last
+
+
+# @spec SM-LC-014 — never loaded -> not added (no signal).
+def test_repair_does_not_add_skill_with_zero_loads(isolated_env):
+    ns = isolated_env
+    # No skill loads at all.
+    _make_opencode_db(ns.opencode_db, [])
+    _index_outcomes(ns)
+
+    _make_skill_on_disk(ns.agents_skills, "never-loaded")
+
+    ns.usage_file.write_text(json.dumps({}))
+
+    summary = autolearn.repair_skill_use_counts()
+    assert summary["added"] == 0
+
+    usage = json.loads(ns.usage_file.read_text())
+    assert "never-loaded" not in usage
+
+
+# @spec SM-LC-015 — archive dirs must be skipped.
+@pytest.mark.parametrize("archive_name", [".archive", ".archive-manual", ".archive-old"])
+def test_repair_skills_in_archive_dirs_not_resurrected(isolated_env, archive_name):
+    ns = isolated_env
+    _make_opencode_db(ns.opencode_db, [("old-skill", 1_000)])
+    _index_outcomes(ns)
+
+    archive_dir = ns.agents_skills / archive_name
+    _make_skill_on_disk(archive_dir, "old-skill")
+
+    ns.usage_file.write_text(json.dumps({}))
+
+    summary = autolearn.repair_skill_use_counts()
+    assert summary["added"] == 0
+
+    usage = json.loads(ns.usage_file.read_text())
+    assert "old-skill" not in usage
+
+
+def test_repair_does_not_touch_existing_created_by(isolated_env):
+    """Even if the skill is also on disk, an existing entry's created_by stays."""
+    ns = isolated_env
+    _make_opencode_db(ns.opencode_db, [("foo", 1_000)])
+    _index_outcomes(ns)
+
+    _make_skill_on_disk(ns.agents_skills, "foo")
+
+    ns.usage_file.write_text(json.dumps({
+        "foo": {
+            "created_by": "user",  # legacy value, must be preserved
+            "created_at": "2026-01-01",
+            "use_count": 0,
+            "patch_count": 0,
+            "last_activity_at": "2026-01-01",
+            "state": "active",
+            "pinned": False,
+        }
+    }))
+
+    summary = autolearn.repair_skill_use_counts()
+    assert summary["updated"] == 1
+    assert summary["added"] == 0
+
+    usage = json.loads(ns.usage_file.read_text())
+    assert usage["foo"]["created_by"] == "user"  # unchanged
+    assert usage["foo"]["use_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _scan_skill_dirs_for_repair() — direct unit tests
+# ---------------------------------------------------------------------------
+
+# @spec SM-LC-013, SM-LC-015
+def test_scan_finds_skills_across_discovery_dirs(isolated_env):
+    ns = isolated_env
+    _make_skill_on_disk(ns.agents_skills, "alpha")
+    _make_skill_on_disk(ns.config_skills, "beta")
+
+    found = autolearn._scan_skill_dirs_for_repair()
+    assert set(found.keys()) == {"alpha", "beta"}
+
+
+def test_scan_skips_archive_dirs(isolated_env):
+    ns = isolated_env
+    _make_skill_on_disk(ns.agents_skills, "live")
+    _make_skill_on_disk(ns.agents_skills / ".archive", "archived-auto")
+    _make_skill_on_disk(ns.agents_skills / ".archive-manual", "archived-manual")
+
+    found = autolearn._scan_skill_dirs_for_repair()
+    assert set(found.keys()) == {"live"}
+
+
+def test_scan_skips_dirs_without_skill_md(isolated_env):
+    ns = isolated_env
+    (ns.agents_skills / "not-a-skill").mkdir()
+    (ns.agents_skills / "not-a-skill" / "README.md").write_text("nope")
+
+    _make_skill_on_disk(ns.agents_skills, "real-skill")
+
+    found = autolearn._scan_skill_dirs_for_repair()
+    assert set(found.keys()) == {"real-skill"}
+
+
+def test_scan_first_seen_wins_across_dirs(isolated_env):
+    """If a skill name appears in multiple discovery dirs, the first one wins."""
+    ns = isolated_env
+    # agents_skills is listed before config_skills in the env var.
+    _make_skill_on_disk(ns.agents_skills, "dup", contents="# agents version\n")
+    _make_skill_on_disk(ns.config_skills, "dup", contents="# config version\n")
+
+    found = autolearn._scan_skill_dirs_for_repair()
+    assert len(found) == 1
+    assert "dup" in found


### PR DESCRIPTION
## ELI5

Skills you install manually (via the skill-installer, hand-authored, or bundled with opencode) had **no usage data** attached to them. The system could not tell an actively-loaded manual skill from a dead one. This came to a head in a session that pruned 84% of skill-usage-token bloat: 65 of 155 skills on disk had zero signal, so we couldn't tell which to archive.

This change wires those skills into telemetry — the system now records how many times each manual skill is loaded and when, just like it already does for skills autolearn creates itself. Manual skills stay observe-only: they're never auto-archived. The data exists so future audits can make principled decisions.

## Technical summary

Extends `repair_skill_use_counts()` to also scan skill-discovery directories for `SKILL.md` files not yet tracked in `.usage.json`. For any on-disk skill that has been loaded at least once (count > 0 in the outcome index), adds an entry with `created_by: "tracked-manual"`. The existing retention filter at `autolearn.py:870` (`meta.get("created_by") != "autolearn"`) already skips these, so they are never auto-archived.

Layering stays clean:
- **autolearn-curator**: still manages only autolearn-created skills (unchanged)
- **repair (this change)**: observes usage on ALL skills for telemetry
- **periodic audits**: the user keeps decision authority over manual skills

## Spec traceability

New EARS requirements in `docs/designs/skill-management/skill-lifecycle-EARS.md`:
- **SM-LC-013**: disk scan during repair
- **SM-LC-014**: add `tracked-manual` entries for loaded untracked skills
- **SM-LC-015**: never resurrect anything in `.archive*` dirs
- **SM-LC-016**: never modify `created_by` on existing entries
- **SM-LC-017**: retention continues to skip non-autolearn entries (already implemented at `autolearn.py:870`, now also tested)

Implementation:
- `outcomes.OutcomeIndex.skill_use_signals()`: extends the existing `skill_use_counts()` with `last_seen_ms` (`MAX(time_created)` per skill).
- `repair_skill_use_counts()`: two phases — refresh existing entries; add `tracked-manual` entries for on-disk untracked skills with loads.
- `_scan_skill_dirs_for_repair()`: walks `~/.agents/skills/` + `~/.config/opencode/skills/`, skips any `.archive*` dir.

## Design rationale (documented in LLD)

The LLD's new "Why Two Stores" section explains why `.usage.json` and `outcomes.db` coexist. TL;DR: `.usage.json` predates `outcomes.db`, only 2 of 8 fields it holds are actually derived (the drift-smell), and the blast radius of consolidation isn't justified yet. Revisit when drift is observed in practice, when a feature needs transactional consistency, or when cross-machine sync wants to ship usage telemetry.

## Tests

- 16 new tests in `test_repair_skill_use_counts.py` (was 13, added SM-LC-017 + symlink coverage)
- 3 new tests in `test_outcomes.py` for `skill_use_signals()`
- Full suite: **126 passed** (6 pre-existing sync-server e2e failures unrelated; require `bun install` in sync-server/)

## Review findings addressed

Two parallel read-only review subagents flagged 5 MAJOR + ~12 MINOR issues. All MAJOR + most MINOR fixed:
- EARS checkboxes flipped to `[x]`
- `@spec SM-LC-017` anchor added
- Test for SM-LC-017 (tracked-manual survives curator run)
- Fixture isolation: monkeypatch DATA_HOME / REGISTRY_FILE
- Stale file:line refs in LLD fixed
- `added` count now printed in curator output
- AUTOLEARN_SKILL_DISCOVERY env var correctly named in docs
- Symlink-handling test pins the `Path.is_dir()` symlink-following behavior

## Out of scope (deliberately)

- Consolidating `.usage.json` + `outcomes.db` into one store (documented in LLD as a known smell; deferred until a concrete pain point justifies the blast radius)
- Project-local skill scan (`.agents/skills/` in repo roots) — documented as known asymmetry
- Cross-machine sync of usage telemetry (open design question; neither store syncs today)