### PR TITLE
feat(long-horizon): cross-session skill proposer + recurrence gate + pruner

### DIFF
--- a/docs/designs/long-horizon-skills/LLD.md
+++ b/docs/designs/long-horizon-skills/LLD.md
@@ -1,0 +1,220 @@
+# Long-Horizon Skill Loop - Low-Level Design
+
+**Created**: 2026-07-19
+**HLD Link**: ../../high-level-design.md
+
+## Overview
+
+Shifts skill creation from **reactive-per-session** (myopic, wasteful) to
+**evidence-driven-cross-session**, and closes the loop by pruning skills that
+never get used. Two halves on the existing Certified Procedures substrate:
+
+- **Half 1 — Proposer.** Study many sessions; cluster by user-request +
+  resolution; recurring clusters **stage a proposal**; a proposal
+  **auto-promotes to a skill only when its common resolution passes
+  falsification** (deterministic verification).
+- **Half 2 — Pruner.** The curator auto-archives skills with `use_count == 0`
+  past a long grace period (using the repaired `use_count`).
+
+And the integration that fixes the myopia at its source: the reviewer's
+`skill create` is **hard-gated** — it may not create a new skill unless the
+proposer confirms the pattern recurs across sessions; otherwise it records a
+memory or strengthens an existing skill.
+
+```
+search.db (user text) + outcomes.db (tool calls) + shortcuts (golden cmd)
+        │
+        ▼
+proposer.py
+  scan()        ── cluster recent sessions by request_signature + resolution;
+                   clusters >= M sessions -> stage a proposal (proposals.json)
+  verify()      ── run falsify on each proposal's common_resolution
+  promote()     ── auto-create the skill when falsification passes
+  is_recurrent()── the reviewer's hard-gate check (CLI: proposals recurrence)
+        │
+        ▼
+existing skill create  ←  promotions only (no per-session myopic creation)
+
+curator (extended)
+  unused pruner ── use_count==0 + age > grace -> auto-archive
+```
+
+## Context — what this replaces
+
+Today the reviewer evaluates one session slice at a time (the plugin buffers
+the current session and spawns a review on that slice). Step 3's `search query`
+is a *lookup* ("have I seen this before?"), not a *synthesis*. Step 7 creates
+skills from what is visible in one conversation, with anti-proliferation guards
+that are starved of signal (until #8, `use_count` was always 0). The result is
+a pile of narrow, often-unused skills and no feedback loop to prune them.
+
+This loop adds the missing long-horizon synthesis (proposer) and the missing
+usage feedback (pruner), and makes the proposer the gatekeeper for creation.
+
+## Data Models
+
+### `proposals.json` (persona-local; not synced)
+
+JSON object keyed by stable proposal id (hash of `request_signature`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | string | `sha1(request_signature)[:16]`. |
+| request_signature | string | `shift.topic_signature(first_substantive_user_msg)` hash. |
+| request_summary | string | Up to N tokens of a representative user message (display). |
+| common_resolution | string \| null | Modal successful bash command across the cluster (the candidate procedure), or null if none consistent. |
+| session_ids | string[] | Sessions in the cluster. |
+| sessions_count | int | `len(session_ids)`. |
+| est_tokens_saved | int | Summed roundabout cost across the cluster (0 if none). |
+| first_seen / last_seen | string | ISO date of earliest/latest session in the cluster. |
+| status | `"pending"` \| `"promoted"` \| `"dismissed"` | Lifecycle. |
+| verified | bool \| null | Falsify verdict on `common_resolution` (null = not run / not falsifiable). |
+| promoted_skill | string \| null | Skill name created on promotion. |
+| updated_at | string | ISO datetime of last scan/verify. |
+
+### Config additions (`config.yaml`)
+
+```yaml
+proposer_recent_sessions: 50     # sessions scanned per pass
+proposer_min_sessions: 3         # cluster size to become a proposal
+proposer_verify_timeout_s: 60    # falsify timeout for common_resolution
+unused_grace_days: 60            # use_count==0 + age > this -> auto-archive
+```
+
+## Component APIs
+
+`proposer.py` imports `outcomes`, `shortcuts`, `falsify`, `shift` (siblings) —
+no `autolearn.py` import. It opens `search.db` and `outcomes.db` read-only
+directly (both are persona-local sqlite files).
+
+```python
+DEFAULT_CONFIG = {...}
+
+def _load_proposals(persona_dir) -> dict
+def _save_proposals(persona_dir, proposals) -> None
+
+def _session_request(search_db, session_id) -> tuple[str, str] | None
+    # (request_signature, request_summary) from the first substantive user msg
+
+def _session_resolution(outcomes_idx, session_id) -> str | None
+    # the last successful bash command in the session (candidate procedure)
+
+def scan(persona_dir, *, config) -> dict
+    # cluster recent sessions; refresh proposals.json; return counts.
+    # Promotes nothing — promotion is a separate, falsify-gated step.
+
+def verify_pending(persona_dir, *, config) -> dict
+    # for each pending proposal with a common_resolution, run
+    # falsify.run_claim (declared, safe-subset); set `verified`.
+
+def promote_ready(persona_dir) -> list[dict]
+    # return pending proposals with verified == True (auto-promote candidates).
+
+def is_recurrent(persona_dir, request_text, *, config) -> dict
+    # {recurrent: bool, sessions_count: int} — the reviewer's hard-gate check.
+
+def cmd_proposals_list(args)
+def cmd_proposals_recurrence(args)
+def cmd_proposals_confirm(args)   # manual override (force-promote)
+def cmd_proposals_dismiss(args)
+```
+
+**Promotion is performed by `autolearn.py`** (which owns `skill create`),
+consuming `promote_ready()`: for each ready proposal, build a minimal SKILL.md
+(name from the resolution, description from the request summary, a `verify:`
+block carrying the common_resolution), run `skill create`, then mark the
+proposal `promoted`.
+
+**Honest auto-promote scope:** a proposal auto-promotes only when its
+`common_resolution` is falsifiable — i.e. in falsify's safe subset (test-runner
+/ self-contained command) AND it passes. Proposals whose resolution is not
+safely falsifiable (e.g. a bare `make build` with no neutral cwd) stay
+`pending` for manual `proposals confirm`. Auto-promote never runs unsafe
+commands.
+
+## Pruner (curator extension)
+
+In `cmd_curator_run`, after `repair_skill_use_counts()`:
+
+```python
+for name, meta in usage.items():
+    if meta.get("state") == "archived" or meta.get("pinned"):
+        continue
+    if meta.get("created_by") != "autolearn":
+        continue
+    use_count = int(meta.get("use_count") or 0)
+    age_days = (today - created_at).days
+    if use_count == 0 and age_days > config["unused_grace_days"]:
+        archive(name, reason="unused")  # existing archive flow
+        transitions["archived"].append(name)
+```
+
+The existing time-staleness path (30 / 90 days) is unchanged; the unused path
+is an additional, independent trigger.
+
+## Reviewer integration (hard gate)
+
+`skills/autolearn-reviewer/SKILL.md` Step 7 gains, before any `skill create`:
+
+```bash
+uv run ... autolearn proposals recurrence "<key terms of the pattern>"
+```
+
+If the result is `recurrent: false` (or the cluster is below
+`proposer_min_sessions`), **the reviewer MUST NOT create a new skill** — it
+records a memory or strengthens an existing skill instead. This makes the
+proposer the gatekeeper for new-skill creation.
+
+## CLI Commands (added to `autolearn.py`)
+
+| Command | Description |
+|---------|-------------|
+| `proposals list` | List pending/promoted/dismissed proposals |
+| `proposals recurrence "<text>"` | The hard-gate check (prints `recurrent=true/false`) |
+| `proposals confirm <id>` | Manually force-promote a pending proposal |
+| `proposals dismiss <id>` | Mark a proposal dismissed |
+
+The curator runs `proposals scan` + `verify_pending` + auto-promote on each
+weekly run (best-effort, like the other CP steps).
+
+## Inspector
+
+`/api/proposals` (pending + recently promoted) and a "unused skills" count in
+the overview, fed by the pruner signal.
+
+## Error Handling
+
+| Condition | Behaviour |
+|-----------|-----------|
+| `search.db` missing (never indexed) | scan returns empty; no proposals; no crash. |
+| `outcomes.db` missing | scan returns empty; reviewer hard-gate answers `recurrent=false` (fail-safe: don't block on missing index). |
+| `common_resolution` unsafe / not in safe subset | `verified` stays null; proposal stays pending (no auto-promote). |
+| Falsify times out | `verified=false`; proposal stays pending. |
+| `skill create` collision (name exists) | promotion skipped, proposal marked promoted anyway (skill already present). |
+
+## Edge Cases
+
+1. **A cluster whose sessions have inconsistent resolutions** — `common_resolution` is null; the proposal is recorded (the recurrence is real signal) but cannot auto-promote; surfaced for manual review.
+2. **Proposal for a skill that already exists** — `promote_ready` skips if a skill with the derived name already exists; marks the proposal `promoted`.
+3. **Pruner vs. a freshly-created skill** — `unused_grace_days` (60) is longer than the time it takes the proposer to surface recurrence, so a newly-created skill has a runway to accrue `use_count` before becoming prune-eligible.
+4. **Reviewer hard-gate on a genuinely novel-but-valuable procedure** — the reviewer records it as a memory; if it recurs in later sessions, the proposer will stage it and auto-promote. Nothing is lost; creation is just deferred until evidence accumulates.
+
+## Dependencies
+
+Python ≥3.11, stdlib only for `proposer.py`. Reuses `outcomes`, `shortcuts`,
+`falsify`, `shift`. No new third-party deps.
+
+## Build Order
+
+1. `proposer.py` + tests (scan / is_recurrent / verify_pending / promote_ready).
+2. `autolearn.py` wiring (`proposals` subcommand + curator scan/verify/promote + pruner).
+3. Reviewer SKILL.md Step 7 hard-gate.
+4. Inspector `/api/proposals` + overview count.
+5. HLD update (decisions + feature rows).
+
+## Related Documents
+
+- [High-Level Design](../../high-level-design.md)
+- [Certified Procedures LLD](../certified-procedures/LLD.md) (the substrate this rides on)
+- [Skill Management LLD](../skill-management/LLD.md) (the `.usage.json` lifecycle this extends)
+- [Review Agent LLD](../review-agent/LLD.md) (Step 7, the creation point this gates)

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -277,6 +277,36 @@ automated "hygiene" loop on a noisy signal makes the system worse than no-op.
   the review flagged; deterministic-first is the genuine Schema-grade path.
 - Auto-demote on correlation: rejected — unsafe on a noisy, drift-blind signal.
 
+### Decision 13: Long-horizon skill loop — evidence-driven creation + usage-driven pruning — _in flight_
+
+**Choice**: Replace reactive-per-session skill creation with a two-part loop on
+the Certified Procedures substrate. (1) A **proposer** studies many sessions,
+clusters by user-request similarity (overlap coefficient + light stemming) +
+the modal resolution, and **stages a proposal** when a cluster recurs across
+≥ N sessions; a proposal **auto-promotes to a skill only when its common
+resolution passes falsification**. (2) The reviewer's `skill create` is
+**hard-gated** on a recurrence check (`proposals recurrence`) — it may not
+create a new skill unless the pattern is cross-session recurrent; otherwise it
+records a memory. (3) A **never-used pruner** auto-archives autolearn-created
+skills with `use_count == 0` past a grace period (using the repaired use_count).
+
+**Rationale**: The reviewer evaluated one session slice at a time and created
+skills from single-conversation patterns, producing a pile of narrow, often-
+unused skills with no feedback loop. The proposer adds the missing long-horizon
+synthesis; the hard gate prevents new myopic creation at its source; the pruner
+closes the loop on waste using the now-repaired use signal. Auto-promotion is
+gated on deterministic falsification, so only verified recurring procedures
+become skills.
+
+**Alternatives considered**:
+- Advisory-only proposer (reviewer free to ignore): rejected — the user flagged
+  the myopic-creation waste; a soft gate would not fix it.
+- Auto-archive never-used immediately: rejected — a grace period gives newly
+  created skills a runway to accrue use before becoming prune-eligible.
+- Human-confirm every proposal: rejected as the default — the user chose
+  falsification-gated auto-promotion; manual confirm remains available via
+  `proposals confirm`.
+
 ## Data Store Layout
 
 ### Current (shipped)
@@ -337,6 +367,9 @@ Existing flat-layout installs are migrated to `personas/default/` automatically 
 | Outcome Index | in flight | Indexes `opencode.db` tool-call + step-cost + skill-load parts the FTS5 index excludes; ground-truth-weighted; repairs `.usage.json` use_count. | `outcomes.py`, `autolearn.py` |
 | Procedure Falsification | in flight | Deterministic verification of skills (test-suite / declared claims); auto-demote + flag failures; probabilistic deferred as suggestion-only. | `falsify.py`, `autolearn.py` |
 | Golden-Path Shortcuts | in flight | Detects expensive roundabout tool sequences, extracts the direct invocation, promotes it gated by falsification. | `shortcuts.py`, `autolearn.py` |
+| Long-Horizon Proposer | in flight | Cross-session clustering of user requests + resolutions; stages proposals; auto-promotes when falsification passes. | `proposer.py`, `autolearn.py` |
+| Reviewer Recurrence Gate | in flight | Hard-gates `skill create` on `proposals recurrence` — ends myopic per-session skill creation. | `autolearn-reviewer/SKILL.md`, `proposer.py` |
+| Never-Used Skill Pruner | in flight | Auto-archives autolearn-created skills with `use_count==0` past a grace period (uses repaired use_count). | `autolearn.py` |
 
 ## Risks and Mitigations
 

--- a/skills/autolearn-reviewer/SKILL.md
+++ b/skills/autolearn-reviewer/SKILL.md
@@ -251,8 +251,29 @@ just check `user list` for semantic duplicates before adding.
 
 ### Step 7: Create or patch skills
 
-If you see a repeatable pattern, technique, or workflow that deserves
-its own skill:
+**HARD GATE — recurrence check (required before ANY `skill create`).** Before
+creating a new skill, you MUST verify the pattern recurs across sessions, not
+just this one conversation (single-session creation is myopic and produces
+wasted, unused skills). Run:
+
+```bash
+uv run $HOME/.agents/skills/autolearn-reviewer/scripts/autolearn.py proposals recurrence "<key terms of the pattern>"
+```
+
+- `recurrent=true` → you MAY create a new skill (proceed to `skill create`).
+- `recurrent=false` → you MUST NOT `skill create`. Record the pattern as a
+  **memory** instead (`memory add`), or **strengthen** an existing skill/memory.
+  If the pattern genuinely recurs in later sessions, the proposer will stage it
+  and auto-promote it once verified — nothing is lost, creation is just deferred
+  until evidence accumulates.
+- If the command errors or the index is missing, treat it as `recurrent=false`
+  (fail-safe: record a memory, do not create).
+
+PATCHING an existing skill (`skill patch`) is **not** gated — patch whenever an
+existing skill was wrong or incomplete.
+
+If you see a repeatable pattern, technique, or workflow that **passed the
+recurrence gate** and deserves its own skill:
 
 ```bash
 uv run $HOME/.agents/skills/autolearn-reviewer/scripts/autolearn.py skill create <name> "<description>"
@@ -266,9 +287,9 @@ uv run $HOME/.agents/skills/autolearn-reviewer/scripts/autolearn.py skill patch 
 
 Preference order for skill actions:
 
-1. PATCH an existing skill that was loaded during the conversation
-2. ADD a section to an existing umbrella skill
-3. CREATE a new skill for a distinct pattern
+1. PATCH an existing skill that was loaded during the conversation (no gate)
+2. ADD a section to an existing umbrella skill (no gate)
+3. CREATE a new skill — **only if `proposals recurrence` returned `recurrent=true`**
 
 **Token-efficiency trigger (acts on signal #7):** when the conversation
 contained EXPENSIVE DISCOVERY (a `--help` chain 2+ levels deep,

--- a/skills/autolearn-reviewer/scripts/autolearn.py
+++ b/skills/autolearn-reviewer/scripts/autolearn.py
@@ -59,6 +59,10 @@ import outcomes
 import falsify
 import shortcuts
 
+# Long-horizon skill loop (proposer + pruner).
+# See docs/designs/long-horizon-skills/LLD.md.
+import proposer
+
 # @spec KS-MEM-020
 DATA_HOME = Path(os.environ.get("AUTOLEARN_HOME", Path.home() / ".autolearn"))
 
@@ -385,6 +389,110 @@ def _scan_skill_dirs_for_repair() -> dict:
                 mtime_iso = date.today().isoformat()
             found[entry.name] = mtime_iso
     return found
+
+
+# @spec LH-PROP-003 — auto-promote verified proposals to skills (gated by falsify)
+def promote_proposals() -> dict:
+    """Create skills for proposals whose common_resolution passed falsification.
+
+    The created skill carries a ``verify:`` block (the common_resolution), so the
+    new skill is itself falsifiable. Mirrors ``cmd_skill_create`` but is driven by
+    proposals and marks each consumed proposal ``promoted``.
+    """
+    proposals = proposer._load(ACTIVE_PERSONA_DIR)
+    ready = [p for p in proposals.values()
+             if p.get("status") == "pending" and p.get("verified") is True]
+    created, skipped = [], []
+    usage = load_usage()
+    for p in ready:
+        name = slugify((p.get("request_summary") or p.get("common_resolution") or "skill"))[:60]
+        if not name:
+            name = "skill"
+        skill_dir = SKILLS_DIR / name
+        skill_file = skill_dir / "SKILL.md"
+        if skill_file.exists() or name in usage:
+            p["status"] = "promoted"
+            p["promoted_skill"] = name
+            skipped.append(name)
+            continue
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        desc = (p.get("request_summary") or "Auto-promoted from a recurring cross-session pattern.")[:200]
+        cmd = p.get("common_resolution") or ""
+        content = (
+            f"---\nname: {name}\ndescription: |\n  {desc}\n"
+            f"created_by: autolearn\ncreated_at: \"{date.today().isoformat()}\"\n"
+            "verify:\n"
+            f"  command: \"{cmd}\"\n"
+            "  expect_exit: 0\n---\n\n"
+            f"# {name.replace('-', ' ').title()}\n\n{desc}\n\n"
+            "## Instructions\n\n"
+            f"This skill was auto-promoted because users repeatedly requested it across "
+            f"{p.get('sessions_count', 0)} sessions, and the direct invocation was "
+            "verified to pass. Replace this TODO with concrete procedural steps.\n"
+        )
+        skill_file.write_text(content)
+        usage[name] = {
+            "created_by": "autolearn", "created_at": date.today().isoformat(),
+            "use_count": 0, "patch_count": 0,
+            "last_activity_at": date.today().isoformat(), "state": "active",
+            "promoted_from": p.get("id"),
+        }
+        link_path = AGENTS_SKILLS_DIR / name
+        AGENTS_SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        if not link_path.exists():
+            try:
+                link_path.symlink_to(skill_dir)
+            except OSError:
+                pass
+        p["status"] = "promoted"
+        p["promoted_skill"] = name
+        created.append(name)
+    save_usage(usage)
+    proposer._save(ACTIVE_PERSONA_DIR, proposals)
+    return {"created": created, "skipped_already_existed": skipped}
+
+
+# @spec LH-PRUNE-001 — never-used pruner (use_count × age)
+def prune_unused_skills(config: dict) -> dict:
+    """Auto-archive autolearn-created skills with use_count==0 past the grace period.
+
+    Uses the repaired use_count (derived from outcomes index skill-load counts).
+    Pinned skills and non-autolearn skills are exempt.
+    """
+    grace = int(config.get("unused_grace_days", 60))
+    today = date.today()
+    usage = load_usage()
+    archived = []
+    for name, meta in list(usage.items()):
+        if meta.get("state") == "archived" or meta.get("pinned"):
+            continue
+        if meta.get("created_by") != "autolearn":
+            continue
+        use_count = int(meta.get("use_count") or 0)
+        if use_count != 0:
+            continue
+        created_str = meta.get("created_at") or meta.get("last_activity_at")
+        if not created_str:
+            continue
+        try:
+            age_days = (today - date.fromisoformat(created_str)).days
+        except ValueError:
+            continue
+        if age_days <= grace:
+            continue
+        skill_dir = SKILLS_DIR / name
+        if skill_dir.exists() and not (ARCHIVE_DIR / name).exists():
+            ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+            try:
+                skill_dir.rename(ARCHIVE_DIR / name)
+            except OSError:
+                continue
+        meta["state"] = "archived"
+        meta["archived_at"] = today.isoformat()
+        archived.append(name)
+    if archived:
+        save_usage(usage)
+    return {"archived": archived, "grace_days": grace}
 
 
 def load_config() -> dict:
@@ -929,6 +1037,23 @@ def cmd_curator_run(args):
     except Exception as exc:
         cp["usage_repaired"] = {"error": str(exc)}
 
+    # @spec LH-PROP-001..003, LH-PRUNE-001 — long-horizon skill loop (best-effort)
+    lh = {"scanned": None, "promoted": None, "pruned": None}
+    try:
+        lh["scanned"] = proposer.scan(ACTIVE_PERSONA_DIR)
+        lh["verified"] = proposer.verify_pending(ACTIVE_PERSONA_DIR)
+        lh["promoted"] = promote_proposals()
+    except Exception as exc:
+        lh["scanned"] = {"error": str(exc)}
+    try:
+        lh["pruned"] = prune_unused_skills(config)
+        if lh["pruned"]["archived"]:
+            transitions.setdefault("archived", []).extend(
+                [n for n in lh["pruned"]["archived"] if n not in transitions["archived"]]
+            )
+    except Exception as exc:
+        lh["pruned"] = {"error": str(exc)}
+
     run_record = {
         "date": today.isoformat(),
         "transitions": transitions,
@@ -936,6 +1061,7 @@ def cmd_curator_run(args):
             {"entry": e, "strength": s} for e, s in escalation_candidates
         ],
         "certified_procedures": cp,
+        "long_horizon": lh,
     }
     state["last_run"] = today.isoformat()
     state["runs"].append(run_record)
@@ -972,6 +1098,14 @@ def cmd_curator_run(args):
             print(f"  usage tracking: repaired use_count on {ur['updated']} skill(s)")
         if ur.get("added"):
             print(f"  usage tracking: newly tracking {ur['added']} manual skill(s)")
+    # Long-horizon skill loop summary
+    lh = run_record.get("long_horizon", {})
+    if isinstance(lh.get("promoted"), dict) and (lh["promoted"].get("created") or lh["promoted"].get("skipped_already_existed")):
+        print(f"  proposals: promoted {len(lh['promoted']['created'])} new skill(s)"
+              + (f", {len(lh['promoted']['skipped_already_existed'])} already existed" if lh["promoted"]["skipped_already_existed"] else ""))
+    if isinstance(lh.get("pruned"), dict) and lh["pruned"].get("archived"):
+        print(f"  pruner: auto-archived {len(lh['pruned']['archived'])} never-used skill(s): "
+              f"{', '.join(lh['pruned']['archived'])}")
 
 
 # @spec SM-LC-010
@@ -2056,6 +2190,18 @@ def main():
     sho_det.add_argument("--dry-run", action="store_true", help="Report without saving candidates")
     sho_sub.add_parser("list", help="List staged golden-path candidates")
 
+    # --- Long-horizon skill loop commands ---
+    pro = sub.add_parser("proposals", help="Cross-session skill proposals + recurrence gate", parents=[persona_parent])
+    pro_sub = pro.add_subparsers(dest="subcommand")
+    pro_sub.add_parser("list", help="List pending/promoted/dismissed proposals")
+    pro_sub.add_parser("scan", help="Scan recent sessions; stage + verify proposals")
+    pro_rec = pro_sub.add_parser("recurrence", help="Hard-gate check: does a request recur across sessions?")
+    pro_rec.add_argument("text", help="The candidate pattern / user request text")
+    pro_conf = pro_sub.add_parser("confirm", help="Manually force-promote a proposal")
+    pro_conf.add_argument("id", help="Proposal id")
+    pro_dis = pro_sub.add_parser("dismiss", help="Dismiss a proposal")
+    pro_dis.add_argument("id", help="Proposal id")
+
     args = parser.parse_args()
     if not args.command:
         parser.print_help()
@@ -2132,6 +2278,13 @@ def main():
         "shortcuts": {
             "detect": shortcuts.cmd_shortcuts_detect,
             "list": shortcuts.cmd_shortcuts_list,
+        },
+        "proposals": {
+            "list": proposer.cmd_proposals_list,
+            "scan": proposer.cmd_proposals_scan,
+            "recurrence": proposer.cmd_proposals_recurrence,
+            "confirm": proposer.cmd_proposals_confirm,
+            "dismiss": proposer.cmd_proposals_dismiss,
         },
     }
 

--- a/skills/autolearn-reviewer/scripts/proposer.py
+++ b/skills/autolearn-reviewer/scripts/proposer.py
@@ -1,0 +1,440 @@
+"""Long-horizon skill proposer — cross-session recurrence → staged proposals.
+
+Replaces reactive-per-session skill creation with evidence-driven-cross-session
+synthesis: study many sessions, cluster by user-request + resolution, and stage
+a *proposal* when a cluster recurs across >= M sessions. A proposal
+auto-promotes to a skill only when its common resolution passes falsification
+(deterministic verification). The reviewer's ``skill create`` is hard-gated on
+``is_recurrent`` so myopic per-session creation can no longer happen.
+
+Reuses the Certified Procedures substrate: ``outcomes`` (tool calls + recent
+sessions), ``shortcuts`` (golden commands), ``falsify`` (verify the resolution),
+``shift`` (topic signatures). Opens ``search.db`` read-only for user-message
+text. No ``autolearn.py`` import.
+
+Spec: docs/designs/long-horizon-skills/LLD.md.
+"""
+from __future__ import annotations
+
+import json
+import hashlib
+import os
+import sqlite3
+from datetime import date
+from pathlib import Path
+
+import falsify
+import outcomes
+import shift
+from shift import topic_signature
+
+DEFAULT_CONFIG = {
+    "proposer_recent_sessions": 50,
+    "proposer_min_sessions": 3,
+    "proposer_verify_timeout_s": 60,
+}
+
+PROPOSALS_FILE = "proposals.json"
+SEARCH_DB_NAME = "search.db"
+MIN_SUBSTANTIVE_LEN = 20
+
+
+# ---------------------------------------------------------------------------
+# Persona / DB resolution
+# ---------------------------------------------------------------------------
+
+def registry_for(args) -> Path:
+    home = Path(os.environ.get("AUTOLEARN_HOME", Path.home() / ".autolearn"))
+    persona = getattr(args, "persona", None) or "default"
+    return home / "personas" / persona
+
+
+def _persona_dir_from(persona_dir: Path) -> Path:
+    return Path(persona_dir)
+
+
+def _search_conn(persona_dir: Path) -> sqlite3.Connection | None:
+    db = persona_dir / SEARCH_DB_NAME
+    if not db.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except sqlite3.Error:
+        return None
+
+
+def _outcomes_idx(persona_dir: Path) -> outcomes.OutcomeIndex:
+    return outcomes.OutcomeIndex(persona_dir / outcomes.OUTCOMES_DB_NAME,
+                                 outcomes._opencode_db_path())
+
+
+# ---------------------------------------------------------------------------
+# Per-session signal extraction
+# ---------------------------------------------------------------------------
+
+def _session_user_messages(search_conn: sqlite3.Connection, session_id: str) -> list[str]:
+    try:
+        rows = search_conn.execute(
+            "SELECT text FROM session_text_content WHERE session_id = ? AND role = 'user' "
+            "ORDER BY timestamp",
+            [session_id],
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [r["text"] for r in rows if r["text"]]
+
+
+def _first_substantive(messages: list[str]) -> str | None:
+    for m in messages:
+        s = (m or "").strip()
+        if len(s) >= MIN_SUBSTANTIVE_LEN and topic_signature(s)[0]:
+            return s
+    return None
+
+
+def _richest_user_message(messages: list[str]) -> str | None:
+    """Pick the user message with the most topic tokens (the strongest request signal).
+
+    Real sessions often start with a short utterance; the richest message is the
+    best proxy for 'what was this session about'.
+    """
+    best, best_n = None, 0
+    for m in messages:
+        s = (m or "").strip()
+        if len(s) < MIN_SUBSTANTIVE_LEN:
+            continue
+        n = len(topic_signature(s)[1])
+        if n > best_n:
+            best, best_n = s, n
+    return best
+
+
+def _stem(tok: str) -> str:
+    """Light plural normalization (test/tests, run/runs). Deliberately tiny."""
+    if len(tok) > 3 and tok.endswith("s"):
+        return tok[:-1]
+    return tok
+
+
+def _stemmed_tokens(text: str) -> set[str]:
+    _sig, tokens = topic_signature(text or "")
+    return {_stem(t) for t in tokens}
+
+
+def _session_request(search_conn, session_id) -> tuple[set[str], str] | None:
+    """Return (stemmed topic tokens, summary) for the session's richest user message."""
+    msgs = _session_user_messages(search_conn, session_id)
+    sub = _richest_user_message(msgs)
+    if not sub:
+        return None
+    tokens = _stemmed_tokens(sub)
+    if len(tokens) < 2:
+        return None
+    summary = sub[:120].replace("\n", " ").strip()
+    return (tokens, summary)
+
+
+def _overlap_coefficient(a: set[str], b: set[str]) -> float:
+    """|A∩B| / min(|A|,|B|). Better than Jaccard for short-vs-long request matches."""
+    if not a or not b:
+        return 0.0
+    return len(a & b) / min(len(a), len(b))
+
+
+SIMILARITY_THRESHOLD = 0.5  # overlap-coefficient threshold to count as same request
+
+
+TRIVIAL_FIRST_TOKENS = {"echo", "ls", "cat", "pwd", "cd", "true", "false",
+                        "export", "printf", "test", "which", "file"}
+
+
+def _session_resolution(idx: outcomes.OutcomeIndex, session_id: str) -> str | None:
+    """The last *meaningful* successful bash command (skip trivial diagnostics).
+
+    Walks the session's bash outcomes newest→oldest and returns the first
+    completed command whose first token isn't a trivial diagnostic (echo/ls/cat/…).
+    """
+    rows = idx.list_tool_outcomes(session_id=session_id, tool="bash")
+    for r in reversed(rows):
+        if r.get("status") != "completed":
+            continue
+        try:
+            inp = json.loads(r.get("input_json") or "{}")
+        except json.JSONDecodeError:
+            continue
+        cmd = inp.get("command")
+        if not (isinstance(cmd, str) and cmd.strip()):
+            continue
+        first = cmd.strip().split()[0]
+        if first in TRIVIAL_FIRST_TOKENS:
+            continue
+        return cmd.strip()
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Proposal store
+# ---------------------------------------------------------------------------
+
+def _load(persona_dir: Path) -> dict:
+    p = persona_dir / PROPOSALS_FILE
+    if not p.exists():
+        return {}
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save(persona_dir: Path, proposals: dict) -> None:
+    p = persona_dir / PROPOSALS_FILE
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    tmp.write_text(json.dumps(proposals, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(tmp, p)
+
+
+def _proposal_id(sig: str) -> str:
+    return sig[:16] or "unknown"
+
+
+def _modal_command(commands: list[str]) -> str | None:
+    """Most frequent command in a cluster (ties: first). None if empty."""
+    if not commands:
+        return None
+    counts: dict[str, int] = {}
+    for c in commands:
+        counts[c] = counts.get(c, 0) + 1
+    return max(commands, key=lambda c: counts[c])
+
+
+# ---------------------------------------------------------------------------
+# Scan / verify / promote
+# ---------------------------------------------------------------------------
+
+# @spec LH-PROP-001
+def scan(persona_dir: Path, *, config: dict | None = None) -> dict:
+    """Cluster recent sessions by request_signature; refresh proposals.json.
+
+    Returns {sessions_scanned, proposals_total, new, updated}. Promotes nothing.
+    """
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    persona_dir = _persona_dir_from(persona_dir)
+    search_conn = _search_conn(persona_dir)
+    idx = _outcomes_idx(persona_dir)
+    proposals = _load(persona_dir)
+
+    sessions = idx.recent_sessions(int(cfg["proposer_recent_sessions"]))
+    # Per-session (topic_tokens_set, summary, resolution, session_id)
+    per_session: list[tuple[set, str, str | None, str]] = []
+    scanned = 0
+    for sid in sessions:
+        req = _session_request(search_conn, sid) if search_conn else None
+        res = _session_resolution(idx, sid)
+        if not req:
+            continue
+        scanned += 1
+        tokens, summary = req
+        per_session.append((set(tokens), summary, res, sid))
+
+    # Greedy single-linkage clustering: a session joins a cluster if it is
+    # similar (>= SIMILARITY_THRESHOLD overlap) to ANY member. Single-linkage
+    # groups varied wordings of the same request that a single-seed compare
+    # would miss.
+    clusters: list[list[tuple[set, str, str | None, str]]] = []
+    for entry in per_session:
+        tokens = entry[0]
+        placed = False
+        for cluster in clusters:
+            if any(_overlap_coefficient(tokens, m[0]) >= SIMILARITY_THRESHOLD for m in cluster):
+                cluster.append(entry)
+                placed = True
+                break
+        if not placed:
+            clusters.append([entry])
+
+    min_sessions = int(cfg["proposer_min_sessions"])
+    today = date.today().isoformat()
+    new = updated = 0
+    for cluster in clusters:
+        if len(cluster) < min_sessions:
+            continue
+        # proposal id = stable hash of the seed's sorted tokens
+        seed_tokens_sorted = sorted(cluster[0][0])
+        pid = hashlib.sha1("|".join(seed_tokens_sorted).encode()).hexdigest()[:16]
+        resolutions = [m[2] for m in cluster if m[2]]
+        summaries = [m[1] for m in cluster]
+        session_ids = [m[3] for m in cluster]
+        existing = proposals.get(pid)
+        rec = {
+            "id": pid,
+            "request_signature": pid,
+            "request_summary": summaries[0] if summaries else "",
+            "common_resolution": _modal_command(resolutions),
+            "session_ids": session_ids,
+            "sessions_count": len(cluster),
+            "est_tokens_saved": 0,
+            "first_seen": today,
+            "last_seen": today,
+            "status": existing.get("status", "pending") if existing else "pending",
+            "verified": existing.get("verified") if existing else None,
+            "promoted_skill": existing.get("promoted_skill") if existing else None,
+            "updated_at": today,
+        }
+        if existing:
+            rec["first_seen"] = existing.get("first_seen", today)
+            updated += 1
+        else:
+            new += 1
+        proposals[pid] = rec
+
+    _save(persona_dir, proposals)
+    if search_conn is not None:
+        search_conn.close()
+    idx.close()
+    return {"sessions_scanned": scanned, "proposals_total": len(proposals),
+            "new": new, "updated": updated}
+
+
+# @spec LH-PROP-002
+def verify_pending(persona_dir: Path, *, config: dict | None = None) -> dict:
+    """Run falsify on each pending proposal's common_resolution.
+
+    verified = True only on a clean pass; False on fail; null on inconclusive /
+    unsafe (proposal stays pending). Auto-promotion consumes only verified=True.
+    """
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    proposals = _load(persona_dir)
+    checked = 0
+    for pid, p in proposals.items():
+        if p.get("status") != "pending":
+            continue
+        cmd = p.get("common_resolution")
+        if not cmd:
+            p["verified"] = None
+            continue
+        checked += 1
+        claim = {"method": "declared", "command": cmd, "expect_exit": 0}
+        res = falsify.run_claim(claim, cwd=Path(persona_dir),
+                                timeout=int(cfg["proposer_verify_timeout_s"]))
+        v = res.get("verdict")
+        p["verified"] = True if v == "pass" else (False if v == "fail" else None)
+        p["verify_evidence"] = res.get("evidence", "")
+    _save(persona_dir, proposals)
+    return {"checked": checked, "verified": sum(1 for p in proposals.values() if p.get("verified") is True)}
+
+
+# @spec LH-PROP-003
+def promote_ready(persona_dir: Path) -> list[dict]:
+    """Pending proposals with verified == True — candidates for auto-promotion."""
+    proposals = _load(persona_dir)
+    return [p for p in proposals.values()
+            if p.get("status") == "pending" and p.get("verified") is True]
+
+
+# @spec LH-PROP-004
+def is_recurrent(persona_dir: Path, request_text: str, *, config: dict | None = None) -> dict:
+    """The reviewer's hard-gate check: does this request recur across >= min_sessions?
+
+    Uses Jaccard similarity (>= SIMILARITY_THRESHOLD) so varied wordings of the
+    same request count as a recurrence. Fail-safe: if search.db is missing or
+    unreadable, returns recurrent=False (the reviewer records a memory instead
+    rather than being blocked on a missing index).
+    """
+    cfg = {**DEFAULT_CONFIG, **(config or {})}
+    target_set = _stemmed_tokens(request_text)
+    if len(target_set) < 2:
+        return {"recurrent": False, "sessions_count": 0, "reason": "no signature"}
+    search_conn = _search_conn(persona_dir)
+    if search_conn is None:
+        return {"recurrent": False, "sessions_count": 0, "reason": "no search index"}
+    try:
+        rows = search_conn.execute(
+            "SELECT DISTINCT session_id FROM session_text_content WHERE role = 'user'"
+        ).fetchall()
+    except sqlite3.Error:
+        search_conn.close()
+        return {"recurrent": False, "sessions_count": 0, "reason": "search schema unreadable"}
+    count = 0
+    for r in rows:
+        sid = r["session_id"]
+        msgs = _session_user_messages(search_conn, sid)
+        hit = False
+        for m in msgs:
+            tokens = _stemmed_tokens(m or "")
+            if len(tokens) >= 2 and _overlap_coefficient(target_set, tokens) >= SIMILARITY_THRESHOLD:
+                hit = True
+                break
+        if hit:
+            count += 1
+    search_conn.close()
+    return {"recurrent": count >= int(cfg["proposer_min_sessions"]),
+            "sessions_count": count}
+
+
+# ---------------------------------------------------------------------------
+# CLI handlers
+# ---------------------------------------------------------------------------
+
+def cmd_proposals_list(args):
+    persona_dir = registry_for(args)
+    proposals = _load(persona_dir)
+    if not proposals:
+        print("No proposals. Run `autolearn proposals scan` first.")
+        return
+    pending = [p for p in proposals.values() if p.get("status") == "pending"]
+    print(f"{len(pending)} pending / {len(proposals)} total proposals:")
+    for p in sorted(pending, key=lambda x: -x.get("sessions_count", 0)):
+        verified = p.get("verified")
+        vmark = "verified" if verified is True else ("failed" if verified is False else "unverified")
+        cmd = (p.get("common_resolution") or "<none>")[:70]
+        print(f"  [{p['id']}] {p['sessions_count']} sessions, {vmark}: {cmd}")
+        print(f"      request: {p.get('request_summary','')[:80]}")
+
+
+def cmd_proposals_scan(args):
+    persona_dir = registry_for(args)
+    summary = scan(persona_dir)
+    print(f"Scanned {summary['sessions_scanned']} sessions: "
+          f"{summary['new']} new proposals, {summary['updated']} updated "
+          f"({summary['proposals_total']} total).")
+    res = verify_pending(persona_dir)
+    print(f"Verified {res['checked']} proposals: {res['verified']} passed (auto-promote-ready).")
+
+
+def cmd_proposals_recurrence(args):
+    persona_dir = registry_for(args)
+    text = getattr(args, "text", "") or ""
+    res = is_recurrent(persona_dir, text)
+    print(f"recurrent={'true' if res['recurrent'] else 'false'} "
+          f"sessions_count={res['sessions_count']}")
+
+
+def cmd_proposals_confirm(args):
+    """Manually force-promote a proposal (bypasses verification)."""
+    persona_dir = registry_for(args)
+    proposals = _load(persona_dir)
+    pid = getattr(args, "id", "")
+    p = proposals.get(pid)
+    if not p:
+        print(f"No proposal {pid}")
+        return
+    p["status"] = "promoted"
+    p["verified"] = True
+    _save(persona_dir, proposals)
+    print(f"Proposal {pid} marked promoted (manual). Create the skill via `skill create`.")
+
+
+def cmd_proposals_dismiss(args):
+    persona_dir = registry_for(args)
+    proposals = _load(persona_dir)
+    pid = getattr(args, "id", "")
+    p = proposals.get(pid)
+    if not p:
+        print(f"No proposal {pid}")
+        return
+    p["status"] = "dismissed"
+    _save(persona_dir, proposals)
+    print(f"Proposal {pid} dismissed.")

--- a/skills/autolearn-reviewer/scripts/test_proposer.py
+++ b/skills/autolearn-reviewer/scripts/test_proposer.py
@@ -1,0 +1,234 @@
+# /// script
+# dependencies = ["pytest"]
+# ///
+"""Tests for proposer.py — long-horizon skill proposal loop."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import proposer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: synthetic search.db + outcomes.db in a persona dir
+# ---------------------------------------------------------------------------
+
+def _persona(tmp_path) -> Path:
+    p = tmp_path / "persona"
+    p.mkdir()
+    return p
+
+
+def _search_db(persona: Path, sessions: dict[str, list[tuple[str, str]]]) -> None:
+    conn = sqlite3.connect(str(persona / "search.db"))
+    conn.executescript(
+        "CREATE TABLE session_text_content("
+        "rowid INTEGER PRIMARY KEY, session_id TEXT NOT NULL, message_id TEXT NOT NULL, "
+        "role TEXT NOT NULL, text TEXT NOT NULL, project TEXT NOT NULL DEFAULT '', "
+        "timestamp INTEGER NOT NULL);"
+    )
+    rid = 0
+    for sid, msgs in sessions.items():
+        for i, (role, text) in enumerate(msgs):
+            conn.execute(
+                "INSERT INTO session_text_content(rowid, session_id, message_id, role, text, project, timestamp) "
+                "VALUES (?,?,?,?,?,?,?)",
+                [rid, sid, f"{sid}-m{i}", role, text, "", i],
+            )
+            rid += 1
+    conn.commit()
+    conn.close()
+
+
+def _idx(persona: Path) -> "proposer.outcomes.OutcomeIndex":
+    idx = proposer.outcomes.OutcomeIndex(persona / proposer.outcomes.OUTCOMES_DB_NAME,
+                                         persona / "opencode.db")
+    return idx
+
+
+def _tool(idx, sess, seq, tool, status, command=None):
+    inp = {"command": command} if command else {}
+    idx.conn.execute(
+        "INSERT INTO tool_outcome(part_id, session_id, message_id, seq, time_created, "
+        "tool, status, skill_name, input_json, output_peek, gt_strength) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        [f"p{sess}{seq}", sess, f"p{sess}{seq}-m", seq, seq, tool, status, None,
+         json.dumps(inp), "", 1],
+    )
+
+
+# A substantive user message that yields a stable topic signature
+REQUEST = "please run the project test suite before committing changes"
+
+
+def _env_with_cluster(tmp_path, n_sessions=3, resolutions=None):
+    persona = _persona(tmp_path)
+    sessions = {f"s{i}": [("user", REQUEST), ("assistant", "ok")] for i in range(n_sessions)}
+    _search_db(persona, sessions)
+    idx = _idx(persona)
+    resolutions = resolutions or ["uv run pytest"] * n_sessions
+    for i, cmd in enumerate(resolutions):
+        _tool(idx, f"s{i}", 10 + i, "bash", "completed", command=cmd)
+    idx.conn.commit()
+    idx.close()
+    return persona
+
+
+# ---------------------------------------------------------------------------
+# scan (LH-PROP-001)
+# ---------------------------------------------------------------------------
+
+def test_scan_stages_recurring_cluster(tmp_path):
+    persona = _env_with_cluster(tmp_path, n_sessions=3)
+    summary = proposer.scan(persona, config={"proposer_min_sessions": 3, "proposer_recent_sessions": 50})
+    assert summary["new"] == 1
+    proposals = proposer._load(persona)
+    assert len(proposals) == 1
+    p = next(iter(proposals.values()))
+    assert p["sessions_count"] == 3
+    assert p["status"] == "pending"
+    assert p["common_resolution"] == "uv run pytest"
+
+
+def test_scan_below_threshold_no_proposal(tmp_path):
+    persona = _env_with_cluster(tmp_path, n_sessions=2)
+    proposer.scan(persona, config={"proposer_min_sessions": 3, "proposer_recent_sessions": 50})
+    assert proposer._load(persona) == {}
+
+
+def test_scan_modal_resolution(tmp_path):
+    # 3 sessions, two with one command, one with another -> modal wins
+    persona = _env_with_cluster(tmp_path, n_sessions=3,
+                                resolutions=["uv run pytest", "uv run pytest", "make test"])
+    proposer.scan(persona, config={"proposer_min_sessions": 3})
+    p = next(iter(proposer._load(persona).values()))
+    assert p["common_resolution"] == "uv run pytest"
+
+
+def test_scan_is_idempotent_and_accumulates(tmp_path):
+    persona = _env_with_cluster(tmp_path, n_sessions=3)
+    proposer.scan(persona, config={"proposer_min_sessions": 3})
+    # re-scan: same cluster -> updated, not new
+    summary = proposer.scan(persona, config={"proposer_min_sessions": 3})
+    assert summary["new"] == 0
+    assert summary["updated"] == 1
+
+
+def test_scan_clusters_varied_wording_via_jaccard(tmp_path):
+    """The whole point: differently-worded requests for the same thing cluster."""
+    persona = _persona(tmp_path)
+    sessions = {
+        "s1": [("user", "please run the project test suite before committing")],
+        "s2": [("user", "run the test suite for this repo")],
+        "s3": [("user", "how do I run all the tests here")],
+    }
+    _search_db(persona, sessions)
+    idx = _idx(persona)
+    # NOTE: outcomes session ids MUST match the search.db session ids —
+    # recent_sessions() reads from outcomes, _session_request reads from search.
+    for sid in ("s1", "s2", "s3"):
+        _tool(idx, sid, 10, "bash", "completed", command="uv run pytest")
+    idx.conn.commit(); idx.close()
+    summary = proposer.scan(persona, config={"proposer_min_sessions": 3})
+    assert summary["new"] == 1, "varied wordings of the same request must cluster"
+
+
+def test_is_recurrent_clusters_varied_wording(tmp_path):
+    persona = _persona(tmp_path)
+    sessions = {
+        "s1": [("user", "run the project test suite before committing")],
+        "s2": [("user", "run the test suite for this repo")],
+        "s3": [("user", "how do I run all the tests")],
+    }
+    _search_db(persona, sessions)
+    idx = _idx(persona); idx.conn.commit(); idx.close()
+    res = proposer.is_recurrent(persona, "please run the tests now", config={"proposer_min_sessions": 3})
+    assert res["recurrent"] is True
+
+
+# ---------------------------------------------------------------------------
+# is_recurrent (LH-PROP-004) — the reviewer hard-gate
+# ---------------------------------------------------------------------------
+
+def test_is_recurrent_true(tmp_path):
+    persona = _env_with_cluster(tmp_path, n_sessions=3)
+    res = proposer.is_recurrent(persona, REQUEST, config={"proposer_min_sessions": 3})
+    assert res["recurrent"] is True
+    assert res["sessions_count"] >= 3
+
+
+def test_is_recurrent_false_for_novel_request(tmp_path):
+    persona = _env_with_cluster(tmp_path, n_sessions=3)
+    res = proposer.is_recurrent(persona, "totally different unrelated request about docker networking",
+                                config={"proposer_min_sessions": 3})
+    assert res["recurrent"] is False
+
+
+def test_is_recurrent_fail_safe_when_no_search_db(tmp_path):
+    persona = _persona(tmp_path)
+    idx = _idx(persona); idx.close()
+    res = proposer.is_recurrent(persona, REQUEST, config={"proposer_min_sessions": 3})
+    assert res["recurrent"] is False  # fail-safe: don't block the reviewer
+
+
+# ---------------------------------------------------------------------------
+# verify_pending + promote_ready (LH-PROP-002, LH-PROP-003)
+# ---------------------------------------------------------------------------
+
+def _stage(persona, command):
+    """Stage one pending proposal with the given common_resolution."""
+    proposer._save(persona, {
+        "abc123def45678901": {
+            "id": "abc123def45678901", "request_signature": "abc123def45678901",
+            "request_summary": "x", "common_resolution": command,
+            "session_ids": ["s1", "s2", "s3"], "sessions_count": 3,
+            "est_tokens_saved": 0, "first_seen": "2026-07-19", "last_seen": "2026-07-19",
+            "status": "pending", "verified": None, "promoted_skill": None, "updated_at": "2026-07-19",
+        }
+    })
+
+
+def test_verify_pending_passing_safe_command(tmp_path):
+    persona = _persona(tmp_path)
+    _stage(persona, "uv run --with pytest pytest --version")  # safe + exits 0
+    res = proposer.verify_pending(persona)
+    assert res["checked"] == 1
+    p = proposer._load(persona)["abc123def45678901"]
+    assert p["verified"] is True
+
+
+def test_verify_pending_unsafe_command_stays_null(tmp_path):
+    persona = _persona(tmp_path)
+    _stage(persona, "make build")  # no test-runner token -> not run -> inconclusive -> None
+    proposer.verify_pending(persona)
+    p = proposer._load(persona)["abc123def45678901"]
+    assert p["verified"] is None
+
+
+def test_promote_ready_returns_only_verified(tmp_path):
+    persona = _persona(tmp_path)
+    proposals = proposer._load(persona)
+    proposals["p1"] = {"id": "p1", "status": "pending", "verified": True, "common_resolution": "x"}
+    proposals["p2"] = {"id": "p2", "status": "pending", "verified": False, "common_resolution": "y"}
+    proposals["p3"] = {"id": "p3", "status": "pending", "verified": None, "common_resolution": "z"}
+    proposals["p4"] = {"id": "p4", "status": "promoted", "verified": True, "common_resolution": "w"}
+    proposer._save(persona, proposals)
+    ready = proposer.promote_ready(persona)
+    assert [p["id"] for p in ready] == ["p1"]
+
+
+# ---------------------------------------------------------------------------
+# confirm / dismiss
+# ---------------------------------------------------------------------------
+
+def test_dismiss_marks_status(tmp_path):
+    persona = _persona(tmp_path)
+    _stage(persona, "uv run pytest")
+    proposals = proposer._load(persona)
+    proposals["abc123def45678901"]["status"] = "dismissed"
+    proposer._save(persona, proposals)
+    assert proposer._load(persona)["abc123def45678901"]["status"] == "dismissed"


### PR DESCRIPTION
Closes the \"myopic skill creation\" gap diagnosed after #7/#8: the reviewer studied ONE session at a time and minted skills from single-conversation patterns, producing a pile of narrow, often-unused skills with no feedback loop.

## What this adds (the \"study 10 sessions, write one skill\" loop)

**1. Proposer (`proposer.py`)** — cross-session synthesis:
- Clusters recent sessions by user-request similarity (**overlap coefficient + light stemming**, single-linkage so varied wordings group) and the modal successful resolution.
- A cluster recurring across ≥ `proposer_min_sessions` (default 3) → **stages a proposal** (`proposals.json`).
- **Auto-promotes to a skill ONLY when the common resolution passes `falsify`** (deterministic, safe-subset). Proposals whose resolution isn't safely falsifiable stay pending for `proposals confirm`.

**2. Reviewer Step 7 hard gate** — fixes the creation source:
- \`skill create\` is **forbidden** unless \`proposals recurrence "<pattern>"\` returns \`recurrent=true\`.
- \`recurrent=false\` → the reviewer records a **memory** instead (or strengthens existing). Nothing is lost; creation is deferred until evidence accumulates.
- \`PATCH\` is ungated (still free).

**3. Never-used pruner** — closes the loop on waste:
- Curator auto-archives autolearn-created skills with \`use_count == 0\` past \`unused_grace_days\` (default 60), using the repaired \`use_count\` from #8.

## Why these choices (per the design forks)
- **Auto-promote if falsification passes** (not human-confirm): the user chose autonomous promotion gated on verification.
- **Auto-archive never-used after long grace** (not flag-only): the user chose active cleanup.
- **Hard recurrence gate** (not soft): directly cures the myopic-creation complaint.

## Verified
- 89 tests green (13 new in \`test_proposer.py\`).
- Real-data scan (49 sessions) stages 5 proposals; \`proposals recurrence "run the tests"\` → \`recurrent=true\` across 1000+ sessions.
- Curator runs the full loop (scan → verify → promote → prune) best-effort each pass.

## Honest caveats
- On real data, **no proposals auto-promoted yet** — detected resolutions (grep/rg/npx) aren't in falsify's safe test-runner subset, so they correctly don't auto-promote; they await \`proposals confirm\` or richer verification.
- Clustering is lexical (embedding-free, per Decision 9) — overlaps on common tokens (run/test/project) can over-match; the \`proposer_min_sessions\` floor is the main brake. Tunable.

## CLI
\`\`\`bash
autolearn proposals scan           # study recent sessions, stage + verify
autolearn proposals list           # pending proposals
autolearn proposals recurrence "<text>"   # the hard-gate check
autolearn proposals confirm <id>   # manual force-promote
autolearn proposals dismiss <id>
\`\`\`

Spec: \`docs/designs/long-horizon-skills/LLD.md\` + HLD Decision 13.