### PR TITLE
feat(proposer): frequent proposals scan (self-contained + cheap)

### DIFF
--- a/skills/autolearn-reviewer/scripts/autolearn.py
+++ b/skills/autolearn-reviewer/scripts/autolearn.py
@@ -403,6 +403,23 @@ def _scan_skill_dirs_for_repair() -> dict:
     return found
 
 
+# @spec LH-PROP-001..003 — full proposer loop as a single CLI entry point
+def cmd_proposals_scan(args):
+    """scan -> verify -> promote. Self-contained for frequent (scheduled) runs."""
+    summary = proposer.scan(ACTIVE_PERSONA_DIR)
+    print(f"Scanned {summary['sessions_scanned']} sessions: "
+          f"{summary['new']} new proposals, {summary['updated']} updated "
+          f"({summary['proposals_total']} total).")
+    res = proposer.verify_pending(ACTIVE_PERSONA_DIR)
+    print(f"Verified {res['checked']} unverified proposals: "
+          f"{res['verified']} passed (auto-promote-ready).")
+    promo = promote_proposals()
+    if promo["created"]:
+        print(f"Promoted {len(promo['created'])} new skill(s): {', '.join(promo['created'])}")
+    if promo["skipped_already_existed"]:
+        print(f"({len(promo['skipped_already_existed'])} proposal(s) matched an existing skill)")
+
+
 # @spec LH-PROP-003 — auto-promote verified proposals to skills (gated by falsify)
 def promote_proposals() -> dict:
     """Create skills for proposals whose common_resolution passed falsification.
@@ -2293,7 +2310,7 @@ def main():
         },
         "proposals": {
             "list": proposer.cmd_proposals_list,
-            "scan": proposer.cmd_proposals_scan,
+            "scan": cmd_proposals_scan,
             "recurrence": proposer.cmd_proposals_recurrence,
             "confirm": proposer.cmd_proposals_confirm,
             "dismiss": proposer.cmd_proposals_dismiss,

--- a/skills/autolearn-reviewer/scripts/proposer.py
+++ b/skills/autolearn-reviewer/scripts/proposer.py
@@ -300,10 +300,12 @@ def scan(persona_dir: Path, *, config: dict | None = None) -> dict:
 
 # @spec LH-PROP-002
 def verify_pending(persona_dir: Path, *, config: dict | None = None) -> dict:
-    """Run falsify on each pending proposal's common_resolution.
+    """Run falsify on each *unverified* pending proposal's common_resolution.
 
-    verified = True only on a clean pass; False on fail; null on inconclusive /
-    unsafe (proposal stays pending). Auto-promotion consumes only verified=True.
+    Only proposals with ``verified is None`` are processed, so frequent scans
+    stay cheap (known-pass proposals are promoted; known-fail proposals are not
+    re-run). verified = True only on a clean pass; False on fail; null on
+    inconclusive / unsafe (stays pending). Auto-promotion consumes verified=True.
     """
     cfg = {**DEFAULT_CONFIG, **(config or {})}
     proposals = _load(persona_dir)
@@ -311,6 +313,8 @@ def verify_pending(persona_dir: Path, *, config: dict | None = None) -> dict:
     for pid, p in proposals.items():
         if p.get("status") != "pending":
             continue
+        if p.get("verified") is not None:
+            continue  # already verified — skip (keeps frequent scans cheap)
         cmd = p.get("common_resolution")
         if not cmd:
             p["verified"] = None


### PR DESCRIPTION
Supports a frequent (2-hourly) scheduled proposals scan.\n\n- `proposals scan` now runs the full loop (scan -> verify -> promote) as one CLI entry point, decoupled from the heavier weekly curator.\n- `verify_pending` only processes proposals with `verified is None`, so repeat scans don't re-run falsify on known results — makes a 2h cadence affordable.\n\n13 proposer tests green. Paired with a launchd schedule (`autolearn-proposals-scan`, every 2h) so cross-session proposals stay fresh across many sessions/tabs per day.